### PR TITLE
First Version of RequestProcessor lib

### DIFF
--- a/.github/workflows/concordium-integration-tests.yml
+++ b/.github/workflows/concordium-integration-tests.yml
@@ -1,0 +1,27 @@
+name: Concordium Integration tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  compose_folder: src/ProjectOrigin.VerifiableEventStore.Tests
+
+jobs:
+  test:
+    runs-on: [self-hosted, concordium-testnet]
+    environment: testnet
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK 6
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "6.0"
+
+      - name: Run integration tests
+        env:
+          AccountAddress: ${{ secrets.AccountAddress }}
+          AccountKey: ${{ secrets.AccountKey }}
+        run: make concordium-tests

--- a/.github/workflows/dotnet-formatting.yml
+++ b/.github/workflows/dotnet-formatting.yml
@@ -1,0 +1,23 @@
+name: Dotnet Verify Formatting
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  compose_folder: src/ProjectOrigin.VerifiableEventStore.Tests
+
+jobs:
+  verify-formatting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK 6
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "6.0"
+
+      - name: Verify formatting
+        run: make verify

--- a/.github/workflows/dotnet-unit-tests.yml
+++ b/.github/workflows/dotnet-unit-tests.yml
@@ -1,0 +1,26 @@
+name: Dotnet Unit Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+env:
+  compose_folder: src/ProjectOrigin.VerifiableEventStore.Tests
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup .NET Core SDK 6
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "6.0"
+
+      - name: Build code
+        run: make build
+
+      - name: Run unit tests
+        run: make unit-tests

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+**/coverage.cobertura.xml
+
 # Created by https://www.toptal.com/developers/gitignore/api/dotnetcore,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=dotnetcore,macos
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "omnisharp.defaultLaunchSolution": "src/Registry.sln",
+    "dotnet-test-explorer.testProjectPath": "src/*.Tests/*.csproj", // filter for .Test to not find Integration tests
+    "dotnet-test-explorer.testArguments": "--collect:\"XPlat Code Coverage\"",
+    "coverage-gutters.coverageFileNames": [
+        "coverage.cobertura.xml"
+    ]
+}

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ src_path = src
 
 default: restore format build unit-tests
 
-verify: build
+verify: unit-tests # Verify code is ready for commit to branch
 	dotnet format $(src_path) --verify-no-changes
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+src_path = src
+
+default: restore format build unit-tests
+
+verify: build
+	dotnet format $(src_path) --verify-no-changes
+
+clean:
+	dotnet clean $(src_path)
+
+restore:
+	dotnet restore $(src_path)
+
+build:
+	dotnet build $(src_path)
+
+format:
+	dotnet format $(src_path)
+
+unit-tests:
+	dotnet test $(src_path) --filter 'FullyQualifiedName!~IntegrationTests'
+
+concordium-tests:
+	dotnet test $(src_path)/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests

--- a/doc/container_diagram.drawio.svg
+++ b/doc/container_diagram.drawio.svg
@@ -1,33 +1,33 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1130px" height="861px" viewBox="-0.5 -0.5 1130 861" content="&lt;mxfile&gt;&lt;diagram id=&quot;ir1_qhydO5nLh8rpua9W&quot; name=&quot;Page-1&quot;&gt;7V1bd+I4Ev41PJLjO/CYQHp2z+ndyenMrR+FLUAbY3ksE8L8+tXVlmRDgBhI03ROd8eybpZLX31VKsk9f7x8+6UA+eI/OIFpz3OSt54/6XneMPLovyxhIxOGMmFeoEQkuXXCM/oHykRHpq5QAomRscQ4LVFuJsY4y2BcGmmgKPDazDbDqdlqDuayRadOeI5BChvZ/kRJuZBP4Q3q9H9BNF+olt1oJO5MQfwyL/Aqk+1lOIPizhKoamSTZAESvNaS/MeePy4wLsVvy7cxTNmoqhET5b5suVt1uYBZuU8B+UZIuVFPDRM6CPKSd9x/WJTLlF659FdabbH5i1446uI7u7gL1eXkTb852ehXT7BAS1jCQiYmgCxgUtWc3LOXRi+nKY5fRNIXlKqm+YDy7KzsDGflGKe44L32hw77oemkLPALbLsD31D5V91ZevVdNU1/r/vNLjbahd1r0YKSCPrGHpqDLt8DwasiVtIkxaYExRzKbDKJDblWTr6pXyCmzRYbmqGAKSjRqymXQIr3vMpXFX3CiPbEc+RMHKgZJSdiMHTMKkQ/ZalaWuj7ABstW84ykO3teIHZziAwhI/+ImpUV9oz1klcQNuF1Re1v4J0JYfiaTVNERUiwuYWLF44ALHZQ/iEL9jggnjRY7MgSumoP0xpWjTnv4GS38EzlusV8kejCMP+WUA2jZkYxguAsrvWWfIVTGl7xvQAKZpn9PeY1sYE5uEVFiWikHIvbyxRkrA6HgpI0D9gyutjUiXHllYePvTCiZRwCYouk7KUNfdQQYsScTlH95sdTUmVAMD6Cd/aYFX20cAnQzhlqb5z5/qDwBCAvqzqg/Lr+p5ZrV0Fns0ILC1ZO1S6gkOhUOKJq6GJczcIDwaU02EqoWBT2qjKEzVcPTnwHguYwyZgDs8DmP7AAszBfoDZqCjyzIpCz6pIPNyHkTdw2ju8rV92/tDrFqnDBlL/mwMiezNzRMRLKguQERCXCGcMeVH2SsWENIG6zjKF5RrCrK4GQXLF2Bx0iM1Oxb4/ODdC38JiS6KPwWI8/R8j8PTpUxDDBSXqsLA4fvBfsJRd/go2XJToLadP/z5Uelrl/W2Ty7yPb/RdZ4DJJtmQEi5VlgkkcYFyJlki5xhnjAPQa557qlVK+QBgvVsjLuSkxAXjB4D9DpkMKhaxAJKLGNSjIiZlAWm5MbuTkVWBsnlddwJKwJsoF7JJWJVwYpBluOQTgF0tQDan4iRy4xW7gcRdUeUrIohKhpwZqZgKE34l5hYTQWPORH+vsLrRJ1yw79kIR/lbfVPNx2qG1gmhfD9s4oub9A1P7QI0TbRsJifotUoKRWX8BdLKwolWVs/XAIm2yg59WnfX08pa4mrm1hn9mP9pKxuakmaMT9tY2I/paaA60CalxFsN9UyQWS9QCZ9zwJXpmprnJhbuxqsZlXMdocbDYBQ1kWvG/7QhKyhihY6t1GDgR4Mhw00KCeAxQaViGjuB98G5Y+M3dvhfJhpjntiWNmgmuuxK1WAmtqUNwrYq3Za27TSvJbG1ypa2HauTXNtspUsNzbBVA0SWCRgpE3BdezYq822hezVsfNc1hIHwNZzTS4noR6D7rxT5NKLA0fV4VG+rTUEuWeU5LoTVx9GWcAhz8gKXmM5zBdVMIBnaxgUmxKQwcQrQktyA9rqAdngD2hvQdgS0QXQ+oG2YYaNDXRqVJ6J2Pnw3fA/HeiJsg+nTOh3UQoPmdHBH5/E62O5Tz9nPWXCEfa6EVDPQH99gvCq5fiQUZYTGw8slyJLKLwo07XfFdveoQ7vbDaLIMpg/Zoafz86+j2M6gLzNKX3jwg3TJGO/cgOU278kxjncy9SOYV6VAqIdIvjWirA+0dSMSSDrIzVq5T0qjGDORTRnjv+4nxfoFZSsyRe44W8RFYyOOT2FpjdSdiWkzNVB98bKbqzsEFZWkatLsDD30EX2jzGnep3b+9hC96UoWHAeulWtgm/zZO+7yONHlm/lRIs8tmmhWNy2fg0HH8sfebvz24tIUceLSG5zvX8MxOIPSCoO0FO+88ayEScQBfx7BQnTNGDJtEA2JTlHXuaTp/wB4xn5/Ex22+QTpXBBedxO7tsy8bpc+Hf8gWuIQjfr/n03MKvte+HArOT0LPh3whyINumlWElqMtxguPeSyNbOxjXQ4kuoRKNE8FYqmPSFcp4gnIns4eYgYyIr3ZK1v/FGaK+J0AY7Ca2GOzpWGPygorrEpLoWg43GUTAYtOnqYMJ+dnBbsgBc5JdvcxbjeRcHdzkXfa8NDy0+2+Cv21jppyCgHJZt4H4XRg9loqFFFvp+CzN12pipHbR36oWYbwbs6OD3zM37Z2bsP7DxAXWm+zynOhnUSPiMZ+Ua8PXyZ80rcA4U0xCkpVb6vsq+lGBWbQpn5ZYp38TCFlg6FCGP75IEVX2od2KrATrhAVa0jTvvWNWG2VLbwJ5jIZJkKNsNh91sZxtHUmjER63Jzaa4LPFyJ2diKIqy+W84lwMgE5Qhzx7wCZRs7ZEmDenQBS1GPC5BqVM/zaoqGK3K5inUTC3RnyeQJKIlhz9Kitf3KoSdcwODkwmLLQeZelO04lVBKNP6BsVEEVlor2SJCo5h8ShCXWVLU4LTVQnva5fFzfGglIFpwLrdKIC+Z5lNbstSfDhs0QBReGYNoAKtWDoLtPqDSu0McYnyRMR0r4qGsnXEmM5hgDKNO8N4kdH5NpePzYkwj2dK2ERYIr7ksIVPP7NGiGqViDFoWIDjym0MqOGZzeViP9M5Dg+qakZsGbFZ0sssw7b4JgzZhgzrag0OZ/XORHCjqJ8zd8RDCXgYWLZaTvltLdL8CkIGeC9ESv1qfxyS/xixn5OT/A6Dtmx1fJAX2/PvvcloB9M/2IvtPA4m95MWBXjzYp/ai62its8YW3Cc5vCl5viK5wynT6sk/pBeFUNPSPcLBW3uauWGCHe/0P8fWRSuHhFWaxcjn9QpjJTxZfEpIPx/XAfqpuIBZdZilcIbxP8sEN9huNgN4m8Qb0C8/2njdBXEBxLin1goRtziLeoW5HXMlv5zEw1z1Y82IJT43CjEAp1QuRTo31aQ2QVT9p54OLDYZiGXloyIKbYjg8NRUYixfIGbynKICyic/rWe4d1ZZXwht9oEwm0KrUs3TfKTaJLRTZPcNMmJNEnldrpECEwV53H5SOSrP2eiZdu0e6aDJuzFrWB0ZEiNXVFoL351FwrtqUAI7VQJynsQX4BXFmDL8RC2fjJ2GBnO0SuOlN4KS5/q+AhTJs3inRwdofa73+Dt9PA2aoG3Mx0L0QjAO/pYCKsi3z8dvEUNePtW2y3aEQwNI6UJcRUKao4vbTuIGWF3xaCnTrf4qUBvH++AFiICqRxp5xoYq4S1R8B2EDhVTZ2sFhKrFyl6gaZpXdngWG4UljmlQ3jJabE6d4HOizkukHD+igVIsf/kvAa6sqkPNsa1gRYWuT1jb+b5LvP8nQMYVKhcvEkRxZXCZ0pOglH4vsE+FWj0ddquqI+333VA3Nue39uA3zvG73gzvGvj2tYjW3nHAUEdrrWZwBtd0tr+PPt+z0dHNTJaU9OL0NFzHevoWyK356mO79XjB/uR0UO3r/Qtm96Lut0uoh5DY7oVEVB7QQDfyyx1PDvng04isaS7aaq0XTSh3njKKrtmC7/TzdAnIrv9wciqdnRuwjuhYnAZkgv4LKhsM3H0mL1zRKwp8SNPzx2ZcKOrl6Gr4tDUG1290dX36Wp0yVNq/J/Re3ohutpyCLk6XPnkx9vYazp2OPuRfLVypp6Yr3a9vdlvema38NVatxd42dRlQtf/LEtO/o/gfe0Pw8sQ0jo+6xf8ys5IzGKoM86Kr35ZlSse5Mo2HukH+zSI5p/i1NsC8maZPgBF0o9xwg0nHura08+HYgnC6QpngsGKyCnuBqZlRejsmvI6skB5T26LEEJMXzSVPpTTsZchVtYxzz9yDNQPwk7Ps/vZv51me4ttOpa/bl2IvQh9Pd7bapDXDr738AlOWWz/KoZ3OMPdj8+2BDv5Z3K/RrbfNDqSzwaDdyo61Uci3jkPyM6vohS6IsBqgmoE+HfCyYQiFRWDsBUkJxQVmWCwn18z5f3UB1Kqj0yZLlg1M7v9RE9XYaTuNUGtGYnlnAZpLwi0ja/xHHtQm/01nsaK2cFA+xFZ9m7ot99XcDqNMT0R+qlqNq3luwG/g3lmV1RsG2EdnP8LZfIpa2h1TgKt+5HPFmfqhT5QFh7LPW0SeypnauODY6PDuKdyFnf2gbIm9+Snm2x6MugflZvKNbXGvbZw2HwBiPhIU/0ds2vG4S5ZaGefIwuGpkq3xLcT5A0PpZ1dHeA7+GwH+FaaoCLQH3Bd7AeyQRNkz/XZXIsuuseCrI3W0Z7h/oeCrP2dX7XKu61fI/sBD8zf9fd9wyYl/iaO+m1825ctN9jhIDY+a6esVuXVgb92XrGy5qRsU/sPgOHdnwccdsmyT3Ue8NA+DtjpYFmNXtbfWxfZ68/Z+4//Bw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1270px" height="831px" viewBox="-0.5 -0.5 1270 831" content="&lt;mxfile&gt;&lt;diagram id=&quot;ir1_qhydO5nLh8rpua9W&quot; name=&quot;Page-1&quot;&gt;7V1bd9q4Fv41PJLlC7bhMYG0M2t1ZnqaufVR2AJ0aiyPZZIwv/7oakuyoWAMSTkkqw2WZUmWtz59++LNwJ+uXz8WIF/9ghOYDjwneR34s4HnucFkQv+wkq0omUSyYFmgRFaqC57Qv1AWOrJ0gxJIjIolxmmJcrMwxlkG49IoA0WBX8xqC5yaveZgKXt06oKnGKSwUe0vlJQrUTr2orr8J4iWK9WzG8r7m4P427LAm0z2l+EMijNroJqRXZIVSPCLVuQ/DvxpgXEpPq1fpzBl06pmTFz3YcfZasgFzMpDLvDkMMqtumuY0EmQh3zg/sOqXKf0yKUfabPF9m964KiDr+zgLlCHs1f95GyrH32GBVrDEhayMAFkBZOq5eSePTR6OE9x/E0UfUCp6ppPKK/Orl3grJziFBd81P7YYb+0nJQF/gbbzsBXVP5dD5YefVVd08/1uNnBVjuwRy16UBJBn9hDc9LlcyB4U8RKmqTYlKBYQllNFrEp166TT+ojxLTbYksrFDAFJXo25RJI8V5W9apLP2NER+I5cilGakXJhTgaO2YTYpzyqlpa6PMAW61aziqQ3f14I7OfaGQIH/0gWlRH2j3WRVxA24XVF60/g3Qjp+LzZp4iKkSErS1YfOMIxFYP4Qu+YJML4tWArYIwpbP+MKdl4ZJ/AiU/gxes1jPkt0YRhv23gmwZMzGMVwBld62r5BOY0/6M5QFStMzo55i2xgTm4RkWJaKQci9PrFGSsDYeCkjQv2DO22NSJeeWNh48DIKZlHAJii6TspR191BBixJxuUYPWx1NSZUAwMYJXw35krAqx2jgkyGc8qqhc+f60cgQgKFs6kT5dYPIbNZuAi8WBJaWrB0rXaNjoVDiiauhiXMXBUcDyvkwlVCwKW1U5YUarp4deLsC5rgJmOPLAKYfWYAZHQaYjYZCz2wo8KyGxM2djLwjx+zHnzh7x2XXD7x+kTpoIPXPHBDZk1kiIh5SWYCMgLhEOGPIi7JnKiakCdR1lTksXyDM6mYQJFeMzaMesdkZj71ewHhiYbFvSXQXLMbz/zICT+8+BTFcUaIOC4vjj34FaznkT2DLRYmecob030O1T6u6v29zWffxlT7rDDDZJFtSwrWqMoMkLlDOJEvUnOKMcQB6zGvPtUYpHwBsdC+ICzkpccH4AWCfIZNBxSJWQHIRg3pUxKQsIL1uys5kZFOgbFm3nYAS8C7KlewSVlc4McgyXPIFwI5WIFtScRK18YadQOKsaPIZEUQlQ66MVCyFGT8Sa4uJoLFmwn82WJ0YEi7Y92yGw/y1PqnWY7VC64JAPh+28MVJ+oTn9gW0TPRsFifouSoKRGP8AdLGgpl2rV6vARJtjR17t+6+u5WtxNXKrSv6Mf9puzYwJc2Yn7a5sG/T00A10halxFsN9UyQeVmhEj7lgG+mL1Q/N7FwP14tqJzrCDUdjyZhE7kW/KcNWUERK3RspQaRH0ZjhpsUEsBjgkrFNPYC74Nzx+Zv6vB/TDSmvLCtLGoWuuxItWAWtpVFQVuTbkvfdpnXUtjaZEvfjjVIvtvspEuNnWHnDhBaKmCoVMCX2rJRqW8r3aphMxZ9hzAQvoZzeigRvQO6/0aRTyMKHF27o3pbawpyySbPcSG0Po62hEOYkxe4xHSdK6hmAsnQNi4wISaFiVOA1uQGtNcFtOMb0N6AtiegHYWXA9qGGjY51qRRWSJq48NXw/bQ1RJhK0zv1uigHA2a0cG9kNXBNp96zmHGgg76uRJSTUH/zwZu+O5IKMaI/Q6v1yBLKqso0Pa+K9a6Jz1q3e4oDE11+UQl/HJa9n0c0wnkfc7pExdGmCYV+42rn1z7JTHO4UGKdgzz6iog+iGCbW0IGxMtzZgEsjFSlVaeo8IIllxEc2b2j4d5gZ5Bybr8Brf8KaKCkTFnoLD0RsmuhJK5OuTeONmNkx3DyVzLCu+/ISVzj/W4n0ajaqe3d5rX+6342Ogy3KtyiVf7dEePjx9ahpYzeXxsPUNRul3jGken1Q+9/fVtj1LYs0fJbTr/p0B4gkBSUYKBMqQ3fEicTxTwH8px2cYD1mxTyOYk50DMDPSUTmC8IO+f2O5afOIqXFBat5cKtyy8PqMAHD9yDVHoJwhg6I7MZoeeCgu4HCn+gzBros2BKVaSmhs3CO+95LWD2pEEtGATKtEoETSWCiZ9oJw2CMsiu7klyJjIShtlbXy88dtr4rejvfxWwx0dKwx+UDFfYjJfi9CG03AURW179WjGfvdQXbICXOTXr0sW8XkXj+5yLvpeGx5a9LZBZ3eR1HfBRzks28D9XRg9lpgGFlkYtjFTp42Z2hF85/bKKJ87K2c+9y8GDOlg+MS1/ydmC3hg8wXqSvd5TvdoUCPjE16UL4A70580o8ElUE1DlJZW6fMrh1KiWbMpXJQ7IKCJjS0wdSxidh+SBFl9qvdirQFCwRFKto1D31G6DTWmVpE9x0IoyVh2KxL72c8uzqTQic9ak6vNcVni9V4OxVAVZcvfcS4nQBYoPZ/d4GdQMsckLRrTqRu16Pi4BKVOBTUtq2A0K1umUFO9xHg+gyQRPTn8VlL8cq/i2zlXMDia0OBykKknRRveFIQyry9QLBRRhY5KXlHBMyweRRys7GlOcLop4X1t0bjZJdTmYCq0bj8bwtC3fABui58+8lp2hIaeee4d4U8qpQvEJcgT4dODKjTK3hOmdM0ClGncGcarjK6vpbxNOhR/J39+Yo0S1QsR99jQ+KaV1RhQRTNbSk8/21McHlHVDNcyArOkkVnGbPE3MGQfMqarNTKctbsQkY2ifc7UEY8j4DFg2WY956e1MPMriBfgoxAl9aP8cUj9Y8h+z07qe4zYsrfbo4zYnn/vzSZ7mP3RRmznMZrdz1o2uJsR+0JG7CqU/N1FcO3WDU7bB/6UhhIyMHzTAvR5RK0e3SWQut4yuJbBbS31RsGYFHd1zwHhf3EdeksHxXcXaTncpPCG2/8vuN1jANgNt2+4beC277xX3H5MaeUCxajsAt0/gSLhyzaBFWDuhPKf13kK1+qVSxF8m8OYKhSxupYzafEehYRyfXhOgtf1i5k3RL52RJ7cEPmGyD0h8tC335a8ICQ3MzCoqIe3D9K9+hQMLW8UuxfKwWC7ekaTjgEmdkOB7QrqL0rYU2EBWsIFSiAQd0crVaolc4K9QRkv3ximwisOI96JS+8qs4Ipk+blvWRVUK+Cd4t3e4PXBCqM0hCqxqsOWR0qzD4hq0N3eJtcBt6GIytezA864tswsBoKz4dvYQPfdtmYdOtRI5EMXHCvhxlURpFwW11JBObthkiBorX35CoRUWWFeM+IOFSxcEr8ekg1c4gaXmvaM1ACw49Wq962Ju5UV1vKOBc0niwgYSiyRvyNnu/51wBfHdWGrivf2juv3OnFkydd2iKqVOajdW1tyoTCbS7Vm/a9X/v2PW29NLVvFRYWb1NEgaHw2b4q0ST4vj4+F3Dyad6+p3dXz3VEO1hdP1g/PzierbuW3bfubG8EO1nFCbr0Jd1SzQRxx5LNXknaG+nSJ/LUHtMZ+t5lyKZnq8BduaZvtlO9U9H5XY0TyKjfJKP1xizfXgCJEQazKPC6uSGJDTtRLOKKVWz/hyCUZr6sPlIXHufW+YifWbKULIY6Yazo5odNueE6Cgsy1N/xbfDEv0T6qwLybhmcgyIZWg4f7VXxyouTwIUgoM58K09SzlAIj/sLpWVkhfKBDJES4ksfM5U9lNOZ5ymtGvnefmSXzw9CLi/z5oN/S2t1c+V0pZ+NtyCjt2Sf3dOt9M0+30G6lfb0uN7xBPUwOtpi+/Qv5NoJ/e9YLA+low0b6oGmz7PwUbVqND76B+E7vNrpq229YRDd6js8w+L8mlnou04Yo0TLN1pVy6XfBNp9ebLda8I/09ftnAf+3hD9Grmyu2ZOsHNlewc6ts+Dft4N/Q7LUd2rm/tM6Kea2bZe3w/4HU3++uJHu1hkdPnvD5B3WUPrW2aOaTFQvtHXBwRdCaHNLN/UQBk0CSF/B3A7kJ5xEZgrjDgveND2nSv5ChCR17xO/X/N4NgnNewtg79nYqy9X/cCh8GxXLCvNFfRe0tz9QZxQKMm8l3qm6YsDud2RT4bQkP7ayZ6SqNlfzWWet9617gm9g0eWb/vr8QKmjz1i0iI1fg6LGaYt+MebHzWchFV16u0WHZd4X1yUpYZ5AfA8P6zZgV9Ut9zZc0a20mznMnpcE8P668oFNXrr4D0H/8H&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
-        <path d="M 440 710 L 440 770 L 799.76 770" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
-        <path d="M 807.76 770 L 799.76 774 L 799.76 766 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 580 670 L 580 770 L 939.76 770" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
+        <path d="M 947.76 770 L 939.76 774 L 939.76 766 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 751px; margin-left: 698px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 751px; margin-left: 841px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: all; white-space: nowrap;">
-                                Publishes merkle roots for each
+                                Publishes merkel roots for each
                                 <br/>
                                 batch of events to the blockchain.
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="698" y="754" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Publishes merkle roots for each...
+                <text x="841" y="754" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Publishes merkel roots for each...
                 </text>
             </switch>
         </g>
-        <path d="M 570.24 500 L 600 500 L 600 550 L 799.76 550" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
-        <path d="M 562.24 500 L 570.24 496 L 570.24 504 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
-        <path d="M 807.76 550 L 799.76 554 L 799.76 546 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 710.24 420 L 740 420 L 740 550 L 939.76 550" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
+        <path d="M 702.24 420 L 710.24 416 L 710.24 424 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 947.76 550 L 939.76 554 L 939.76 546 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 531px; margin-left: 701px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 521px; margin-left: 841px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 Inter registry transactions invokes
@@ -37,16 +37,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="701" y="534" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="841" y="524" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Inter registry transactions invokes...
                 </text>
             </switch>
         </g>
-        <rect x="810" y="710" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="all"/>
+        <rect x="950" y="710" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 770px; margin-left: 811px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 770px; margin-left: 951px;">
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 16px">
@@ -61,7 +61,7 @@
                                 <div>
                                     <font style="font-size: 11px">
                                         <font color="#cccccc">
-                                            Conventional blockchain that will store a series of hashes for each merkle tree, ensuring that data within the tree cannot be changed without it being visible.
+                                            Conventional blockchain that will store a series of hashes for each merkel tree, ensuring that data within the tree cannot be changed without it being visible.
                                         </font>
                                     </font>
                                 </div>
@@ -69,16 +69,16 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="930" y="774" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="1070" y="774" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Layer 1 - Blockchain...
                 </text>
             </switch>
         </g>
-        <rect x="810" y="490" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="all"/>
+        <rect x="950" y="490" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 550px; margin-left: 811px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 550px; margin-left: 951px;">
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 16px">
@@ -101,34 +101,34 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="930" y="554" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="1070" y="554" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Other registries...
                 </text>
             </switch>
         </g>
-        <path d="M 440 150 L 440 219.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
-        <path d="M 440 227.76 L 436 219.76 L 444 219.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 580 180 L 580 319.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
+        <path d="M 580 327.76 L 576 319.76 L 584 319.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 185px; margin-left: 439px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 245px; margin-left: 579px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: all; white-space: nowrap;">
-                                Executes signed commands to a registry.
+                                Queues signed commands to a registry.
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="439" y="188" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Executes signed commands to a registry.
+                <text x="579" y="248" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Queues signed commands to a registry.
                 </text>
             </switch>
         </g>
-        <rect x="320" y="30" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="all"/>
+        <rect x="460" y="60" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 90px; margin-left: 321px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 120px; margin-left: 461px;">
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 16px">
@@ -151,38 +151,38 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="440" y="94" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="580" y="124" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Account abstraction...
                 </text>
             </switch>
         </g>
-        <path d="M 810 180 L 810 240 L 1070 240 L 1070 650 L 600 650 L 570.24 650" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
-        <path d="M 562.24 650 L 570.24 646 L 570.24 654 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 950 180 L 950 240 L 1210 240 L 1210 650 L 740 650 L 710.24 650" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
+        <path d="M 702.24 650 L 710.24 646 L 710.24 654 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 261px; margin-left: 931px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 261px; margin-left: 1071px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 Can read public data
                                 <br/>
-                                and request merkle-proofs
+                                and request merkel-proofs
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="931" y="264" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="1071" y="264" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Can read public data...
                 </text>
             </switch>
         </g>
-        <ellipse cx="860" cy="40.5" rx="40.5" ry="40.5" fill="#6c6477" stroke="#4d4d4d" pointer-events="all"/>
-        <path d="M 760 105.3 C 760 82.93 778.13 64.8 800.5 64.8 L 919.5 64.8 C 941.87 64.8 960 82.93 960 105.3 L 960 139.5 C 960 161.87 941.87 180 919.5 180 L 800.5 180 C 778.13 180 760 161.87 760 139.5 Z" fill="#6c6477" stroke="#4d4d4d" stroke-miterlimit="10" pointer-events="all"/>
-        <ellipse cx="860" cy="40.5" rx="40.5" ry="40.5" fill="#6c6477" stroke="#4d4d4d" pointer-events="all"/>
+        <ellipse cx="1000" cy="40.5" rx="40.5" ry="40.5" fill="#6c6477" stroke="#4d4d4d" pointer-events="all"/>
+        <path d="M 900 105.3 C 900 82.93 918.13 64.8 940.5 64.8 L 1059.5 64.8 C 1081.87 64.8 1100 82.93 1100 105.3 L 1100 139.5 C 1100 161.87 1081.87 180 1059.5 180 L 940.5 180 C 918.13 180 900 161.87 900 139.5 Z" fill="#6c6477" stroke="#4d4d4d" stroke-miterlimit="10" pointer-events="all"/>
+        <ellipse cx="1000" cy="40.5" rx="40.5" ry="40.5" fill="#6c6477" stroke="#4d4d4d" pointer-events="all"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 123px; margin-left: 860px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 123px; margin-left: 1000px;">
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: nowrap;">
                                 <font style="font-size: 16px">
@@ -207,22 +207,22 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="860" y="126" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                <text x="1000" y="126" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
                     User...
                 </text>
             </switch>
         </g>
-        <rect x="0" y="210" width="580" height="650" fill="none" stroke="#808080" stroke-dasharray="8 4" pointer-events="none"/>
+        <rect x="0" y="210" width="720" height="620" fill="none" stroke="#808080" stroke-dasharray="8 4" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-start; width: 562px; height: 1px; padding-top: 849px; margin-left: 10px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-start; width: 702px; height: 1px; padding-top: 819px; margin-left: 10px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
                             <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 16px">
                                     <b>
                                         <div style="text-align: left">
-                                            Registry
+                                            Layer 2 - Registry
                                         </div>
                                     </b>
                                 </font>
@@ -233,31 +233,95 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="10" y="849" fill="#808080" font-family="Helvetica" font-size="11px">
+                <text x="10" y="819" fill="#808080" font-family="Helvetica" font-size="11px">
+                    Layer 2 - Registry...
+                </text>
+            </switch>
+        </g>
+        <rect x="460" y="550" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 610px; margin-left: 461px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Verifiable event store
+                                    </b>
+                                </font>
+                                <div>
+                                    [Container: C#]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        <font color="#E6E6E6">
+                                            Stores events as public data, and arranges them in a series of merkel trees, each root publishes to the blockchain after a set time or number of events.
+                                        </font>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="580" y="613" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Verifiable event store...
+                </text>
+            </switch>
+        </g>
+        <rect x="460" y="330" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 390px; margin-left: 461px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Registry
+                                    </b>
+                                </font>
+                                <div>
+                                    [Container: C#]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        <font color="#E6E6E6">
+                                            Validates commands and ensures that the events are valid and allowed based on the logic and rules.
+                                        </font>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="580" y="393" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
                     Registry...
                 </text>
             </switch>
         </g>
-        <rect x="320" y="590" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
+        <rect x="40" y="330" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 650px; margin-left: 321px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 390px; margin-left: 41px;">
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 16px">
                                     <b>
-                                        Layer 2 - Verifiable event store
+                                        Electricity
                                     </b>
                                 </font>
                                 <div>
-                                    [Container: to be determined]
+                                    [Container: Hard coded rules]
                                 </div>
                                 <br/>
                                 <div>
                                     <font style="font-size: 11px">
                                         <font color="#E6E6E6">
-                                            Stores events as public data, and arranges them in a series of merkle trees, each root publishes to the blockchain after a set time or number of events.
+                                            Implements the specific ruleset for the electricity domain.
                                         </font>
                                     </font>
                                 </div>
@@ -265,89 +329,17 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="440" y="653" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Layer 2 - Verifiable event store...
+                <text x="160" y="393" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Electricity...
                 </text>
             </switch>
         </g>
-        <rect x="320" y="410" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
+        <path d="M 580 450 L 580 539.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 580 547.76 L 576 539.76 L 584 539.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 470px; margin-left: 321px;">
-                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
-                                <font style="font-size: 16px">
-                                    <b>
-                                        Layer 3 - Logic
-                                    </b>
-                                </font>
-                                <div>
-                                    [Container: to be determined]
-                                </div>
-                                <br/>
-                                <div>
-                                    <font style="font-size: 11px">
-                                        <font color="#E6E6E6">
-                                            Validates events that they are valid Ensures that events are valid and allowed based on the logic and rules.
-                                        </font>
-                                    </font>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="440" y="473" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Layer 3 - Logic...
-                </text>
-            </switch>
-        </g>
-        <rect x="320" y="230" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 290px; margin-left: 321px;">
-                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
-                                <font style="font-size: 16px">
-                                    <b>
-                                        Layer 4 - Privacy
-                                    </b>
-                                </font>
-                                <div>
-                                    [Container: to be determined]
-                                </div>
-                                <br/>
-                                <div>
-                                    <font style="font-size: 11px">
-                                        <font color="#E6E6E6">
-                                            Ensures the
-                                            <b>
-                                                privacy
-                                            </b>
-                                            and
-                                            <b>
-                                                commitments
-                                            </b>
-                                            , by enabling requests signed with correct keys to create events and unlock data in commitments.
-                                        </font>
-                                    </font>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="440" y="293" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
-                    Layer 4 - Privacy...
-                </text>
-            </switch>
-        </g>
-        <path d="M 440 530 L 440 579.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 440 587.76 L 436 579.76 L 444 579.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 561px; margin-left: 441px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 498px; margin-left: 581px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 Persist valid events to the
@@ -357,90 +349,39 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="441" y="564" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="581" y="501" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Persist valid events to the...
                 </text>
             </switch>
         </g>
-        <path d="M 440 350 L 440 399.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 440 407.76 L 436 399.76 L 444 399.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 460 390 L 290.24 390" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 282.24 390 L 290.24 386 L 290.24 394 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 381px; margin-left: 441px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 421px; margin-left: 371px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
-                                Requests transaction to create
+                                Validates commands are valid
                                 <br/>
-                                events on the registry.
+                                before they are sent to the
+                                <br/>
+                                eventstore
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="441" y="384" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Requests transaction to create...
+                <text x="371" y="424" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Validates commands are valid...
                 </text>
             </switch>
         </g>
-        <path d="M 20 335 C 20 326.72 73.73 320 140 320 C 171.83 320 202.35 321.58 224.85 324.39 C 247.36 327.21 260 331.02 260 335 L 260 425 C 260 433.28 206.27 440 140 440 C 73.73 440 20 433.28 20 425 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
-        <path d="M 260 335 C 260 343.28 206.27 350 140 350 C 73.73 350 20 343.28 20 335" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 40 565 C 40 556.72 93.73 550 160 550 C 191.83 550 222.35 551.58 244.85 554.39 C 267.36 557.21 280 561.02 280 565 L 280 655 C 280 663.28 226.27 670 160 670 C 93.73 670 40 663.28 40 655 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 280 565 C 280 573.28 226.27 580 160 580 C 93.73 580 40 573.28 40 565" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 393px; margin-left: 21px;">
-                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
-                                <font style="font-size: 16px">
-                                    <b>
-                                        Secret data store
-                                    </b>
-                                </font>
-                                <div>
-                                    [Container : to be determined]
-                                </div>
-                                <br/>
-                                <div>
-                                    <font style="font-size: 11px">
-                                        <font color="#E6E6E6">
-                                            Stores secret data like commitments and other data that might be categorised as private.
-                                        </font>
-                                    </font>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="140" y="396" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Secret data store...
-                </text>
-            </switch>
-        </g>
-        <path d="M 320 290 L 140 290 L 140 309.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 140 317.76 L 136 309.76 L 144 309.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 271px; margin-left: 151px;">
-                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
-                                Stores and reads data protected by
-                                <br/>
-                                commitments and other private data.
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="151" y="274" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Stores and reads data protected by...
-                </text>
-            </switch>
-        </g>
-        <path d="M 20 705 C 20 696.72 73.73 690 140 690 C 171.83 690 202.35 691.58 224.85 694.39 C 247.36 697.21 260 701.02 260 705 L 260 795 C 260 803.28 206.27 810 140 810 C 73.73 810 20 803.28 20 795 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
-        <path d="M 260 705 C 260 713.28 206.27 720 140 720 C 73.73 720 20 713.28 20 705" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 763px; margin-left: 21px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 623px; margin-left: 41px;">
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 16px">
@@ -463,36 +404,36 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="140" y="766" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="160" y="626" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Datastore...
                 </text>
             </switch>
         </g>
-        <path d="M 320 650 L 140 650 L 140 679.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 140 687.76 L 136 679.76 L 144 679.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 460 610 L 290.24 610" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 282.24 610 L 290.24 606 L 290.24 614 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 631px; margin-left: 141px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 631px; margin-left: 376px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 Stores and reads events from
                                 <br/>
-                                the event store.
+                                the datastore.
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="141" y="634" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="376" y="634" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Stores and reads events from...
                 </text>
             </switch>
         </g>
-        <rect x="810" y="300" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="none"/>
+        <rect x="950" y="300" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 360px; margin-left: 811px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 360px; margin-left: 951px;">
                         <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
                                 <font style="font-size: 16px">
@@ -515,17 +456,17 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="930" y="364" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="1070" y="364" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Governance...
                 </text>
             </switch>
         </g>
-        <path d="M 560 440 L 600 440 L 600 360 L 799.76 360" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 807.76 360 L 799.76 364 L 799.76 356 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 700 360 L 939.76 360" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 947.76 360 L 939.76 364 L 939.76 356 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 381px; margin-left: 701px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 381px; margin-left: 851px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 Uses rules defined
@@ -535,17 +476,17 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="701" y="384" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="851" y="384" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Uses rules defined...
                 </text>
             </switch>
         </g>
-        <path d="M 930 490 L 930 430.24" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 930 422.24 L 934 430.24 L 926 430.24 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1070 490 L 1070 430.24" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 1070 422.24 L 1074 430.24 L 1066 430.24 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 462px; margin-left: 931px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 462px; margin-left: 1071px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 Uses rules defined
@@ -555,17 +496,17 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="931" y="465" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="1071" y="465" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Uses rules defined...
                 </text>
             </switch>
         </g>
-        <path d="M 570.24 620 L 600 620 L 600 580 L 810 580" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 562.24 620 L 570.24 616 L 570.24 624 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 710.24 580 L 950 580" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 702.24 580 L 710.24 576 L 710.24 584 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 601px; margin-left: 701px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 601px; margin-left: 841px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 Verify validity of two
@@ -575,30 +516,30 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="701" y="604" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                <text x="841" y="604" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
                     Verify validity of two...
                 </text>
             </switch>
         </g>
-        <path d="M 910 180 L 910 210 L 1120 210 L 1120 770 L 1060.24 770" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 1052.24 770 L 1060.24 766 L 1060.24 774 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 1050 180 L 1050 210 L 1260 210 L 1260 770 L 1200.24 770" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 1192.24 770 L 1200.24 766 L 1200.24 774 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 1041px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 1181px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
-                                Read merkle roots to
+                                Read merkel roots to
                                 <br/>
-                                validate merkle proofs
+                                validate merkel proofs
                                 <br/>
                                 from layer.
                             </div>
                         </div>
                     </div>
                 </foreignObject>
-                <text x="1041" y="184" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Read merkle roots to...
+                <text x="1181" y="184" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Read merkel roots to...
                 </text>
             </switch>
         </g>

--- a/doc/layer2_verifiable_event_store/README.md
+++ b/doc/layer2_verifiable_event_store/README.md
@@ -15,6 +15,7 @@ An event will be added to the new batch with a reference to the previous batch, 
 
 Hashing is done with SHA256.
 
+
 ## Endpoints
 
 ### 1. PublishEvent

--- a/doc/layer2_verifiable_event_store/component_diagra.drawio.svg
+++ b/doc/layer2_verifiable_event_store/component_diagra.drawio.svg
@@ -1,4 +1,4 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="731px" height="901px" viewBox="-0.5 -0.5 731 901" content="&lt;mxfile&gt;&lt;diagram id=&quot;FBxYk-bCOjcYe218ZED0&quot; name=&quot;Page-1&quot;&gt;7Zxbd6M2EIB/jR+TgwFj+zG+7PZh25OTbC/7KINs6GJEhZzY/fUd3biIS22vEzstySaxBjG6IH0zDMMOnPl2/5miNPyZBDge2FawHziLgW1Phy785oKDFIy8sRRsaBRI0bAQPEd/YyW0lHQXBTirVGSExCxKq0KfJAn2WUWGKCWv1WprEldbTdEG1wTPPorr0t+jgIVSOrHHhfwnHG1C3fLQm8ojW6Qrq5FkIQrIa0nkLAfOnBLC5Kftfo5jPnd6XuR5n1qO5h2jOGENJ5DVn3w+oEaMfBzCuDE1psz9BW3VML+gA6YgA7k3sB2YfWf2G6bROkIrmArbwi+8GRgFIxTr878eUnX+nCQMRQmmzz5J8YzskgDRg673kKZx5CMWkcSoLmvEaAWrRhyB9mMYzmxNVHMHdSW8v3ZEH7jLxDp5gApDL90XB+HTRv0VWlamIIheGrUyvGd3KI42iVQb4zVrUjtSk2aPtEaYcKG02g5Ia22DTI7qol0ayV6Vpxg6N1q09c8ur6Fxvg7z9VV0xKb8MmJed6gmXu3PIS+/hhHDzyksLpC8wuYHWci2saoeoCzMz0XUV6fafGWtoziek5hQECQkAfksY5R8x1oIS3Bi8W/VbpNcLJoZ8r9vRD8NfWriFmLWnNkLpgymJ35Q4hVhjGxzLYTC7jB7BEOLks1XAgNbWIWAD8lSA3xEjGHKFU5g6lyQbjFDyyBiauCUMMTEFpI6UthTUAXzdijsT5RsYvxYCGV/HlEQyJYsMZSYvD5olnGJgl1JL96nKAlUARTvaBa94CcsN4qsAr1SZ/CepSRKoMkl39daL1plJN4x/JBfrrymQMeILzfrni/+uSV++DqbC2GTbFwXDnlJa6gKm2TjUZPKYUPbpsxuEDaqbGjbMjoJ//TWKfNWcZSvLbwvidSG+owJXFVOQUsdHSlToGyh46nya2FZxo6ShSWr4uqKSBF8k6sugA8f1CbWRWUCfsAcwCHrDn5mMfG/+yEgu47+5Z5vASTYccgY3uoqC5z5NEor1OerDcqi9qqk1GIhYmImFISElbEQ/wy7AzwA2yJrPi0cK5mw5LyDGPkhN7aYfhdmilGM+TWEI0m2o3wT5boD2ImiCRaqJoszLB8lCeG1VqIUwsYEesnaZMcPRPKoVPkSZRHspfv3s1+NluckG1M1GOICdloK1QXapezU0Q67Rqu0+Dnsi4qOL75aTHJ5pVXmp2kuugyi6xxpEK1/N4Dd9qlsArlVm0/cqVe3dmvxVbJnPk6koShMqrBGNfs5drzxxG6wSNwmlC1ST/cL0X04qeJ9atXxbrsNeB/aV8K7o/D+hWwiv8Opzw9hP0xgiW3UCBnRwAy4+7KFukEr/X+DJQwIFvDG0uvI0QwoPogbNq7rhVeEv0tOcFyqlZ9VrccdH/jNvSSB7BXKxF9SQD6WA1RV6S7G2X8A3aIXUlJcmI+D9KXHv98c6d7lkG7eAp2EeNt5sBfTSyLeWo4XD4se8ddD/LDBg78m4gt2L8DZrcRqCpibbLfa8A7+OYrvYBlzCLdQ/Zm3kUn+lhEt3XNJX4o3USbnUTjeK8T88L0JrKF5Mm1LMyWR66Et50KyytJcec/fVv5OO/mbhUgsWf8QRwBi6nDQKeiN/p3IK4nvLystqPL8fEBr8NqnAPtoQteIfHnOXpqeplG5SDikStPJ5LZoWjjMv2YlJzhn7COcQpJWNPLduRMn5tENpLxeot1X8IcFgPOgux+jaCt4ukFJxhoY+tG91g9Cx/cJOIy6vdMO3zOPr+d+a1alpEE3b+6543ETpNwF/+7gnGb0dr/hz/juffc+FUvfboLguai7Ce+xEXVVm3IJ8NmGG2k3gM9qAt/kncE3E65aA/vmZJuCFeWrvdl5bMXiT9BkJQawS1gUa7eQ7w0uTHerOJKh3rmIL6zBBRNRYP6oZqCiwVrHPL+39ylWMQYZE77jD1j7e/23pelFidjtL75dCNZzZstPJ7l7xf2518RV25p482l/e37S7XkNog2oPfr23L3ZCKx47PpIyctl2foZy/hootmYc1HDdU3JNncqeZDgWT9qM/ApayiIpkDRtXFXL/T3ZP04ZPWsnqw9Wc8jq3mrfrtkLacqWHOZKEMuCtnfaaQQSeEWHflyZ/IMRB4n1CkHJXqKHD91188zEMqJD4XnGsKfWIZSd3B6wlQ6V4/YD4TYYY/YHrGXcV690W0htkDnE44FmbIwSlsp6QC3rEd5Fz8oZWg9SRhSzHY0yarBzwKMdyW23lG8bmXgSdmz/DpZTVgQu7uFj8e2kO+sM9pYHQ2wZi1dDGvid3PGcjvWJp1Yw0kg0lOhJK7gV55f1/ngvC2nV2JIJ9pznoHuTzwnUOppzxLG8Up0QCf61skFmnQXXKEKUVYW/Lnbps9qUABHLVE1OCSr+K4kOHfDGu8j9gc/jWNDFr/pXsHnxX6gs3ihcCgVSpnBUpbAti5r4uVv5YOFLlE6lEumNnmRcVB7A6IW2szIjvq4HKABdwbRDWYNdq+OtjvB0DaWUYGTl2onmlim9D9yk1MoH1exORoZNJR9VycVQKzpGRqKvKGhSA64Q5GuSNbrDFfqCPrm83IdILscyJ95v2Q6bxEM6Al8+wTujor2BD6awOOLEXj8EQj8BsDNX1vIX+k7k7jO0CCu6ci2EPcWaDoqubelx018dsHBNV9QKPiqwrCVp1cyMiBDBgWA2+/7e+K+A3HH3dHSnrhHE/diwL0Wbz394nGJt5U3ReoeL/jnk9H4zXxe10DwxD0Twaai6fi/5fQWAYiZJG9O4tcQ86itPRgt9z1pr0patyftD5E2J2SFjyX/9BRE5twuUbsUtzge3JfzbSspIU2stSyNaP1m7ZuRd+h4965VfBntTkfncdh8Ndgzfeof4DDsHnQo1VAh+/YhGtlprmN19r1Wf1qpDx9kD27GKAyroWmVKNGbgCuagO402N4E/H+cbfm+3nEG4B08a9t0iM/1rPOMiQ8Q3LCLUPHPOqzxqFPAZMxYQPOpDwtfmZv9g7mem4qRDdysZPy9MTcnl+KmociZfhxuPmFUvNowMFJve05ekZP947Oek2UmGsHc9/Mvx0Yi7dkPz0xFx0YMboGTIoO25+TtcXLSP/S6CCc1Gb9VmHmN2Ok7os2bGmhzzkSbqWhypAt4aqCzdovudQc6zfqedclAJxSL/wxYnl38j8rO8h8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="731px" height="901px" viewBox="-0.5 -0.5 731 901" content="&lt;mxfile&gt;&lt;diagram id=&quot;FBxYk-bCOjcYe218ZED0&quot; name=&quot;Page-1&quot;&gt;7Zxde6LIEoB/jZfJgyCgl/FjZi92z5MnmbO7c9lCK8wgzTZtovvrT/UXNAgc45ioMySTUYqi+sPut4qi24Ez2+w+U5RFf5AQJwPbCncDZz6w7aHtjuGFS/ZS4vq+FKxpHCqlUvAc/4uV0FLSbRzivKLICElYnFWFAUlTHLCKDFFKXqtqK5JUS83QGh8IngOUHEr/ikMWSenY9kv5bzheR7rkoTeRZzZIK6uW5BEKyashchYDZ0YJYfLdZjfDCe883S/yuk8tZ4uKUZyyhgvI8hvvD9BIUIAjaDemtS4b/QdtVDN/R3tMQQZyb2A70PvO9E9M41WMltAVtoVfeDHQCkYo1td/2Wfq+hlJGYpTTJ8DkuEp2aYhonut95BlSRwgFpO0pi41ErSEYSPOQPkJNGe6Iqq4vfokvH+2RJ+4y8U4eQCFoZftypPwbq1ehZVlXRDGL41WGd6xO5TE61SaTfCKNZl1VafZrrYIHS6MVssB6UHZIJOtOmuVXFkrs4uhcu68rX62OYb8YhwW46usiE35x4i57lB1vJqfQ378GsUMP2cwuEDyCrMfZBHbJEo9RHlUXItooC61+chaxUkyIwmhIEhJCvJpzij5jrUQhuDY4r+q3Ca5GDRTFHxfi3rW7KmOm4tec6YvmDLonuRBiZeEMbIprBAKs6NeI2hanK6/EGjY3CoFvEmWauAjYgxTbhAwZ41AusEMLcKYqYZTwhATU0jayGBOgQrm5VCYnyhdJ/ixFMr6PKIwlCVZoikJeX3QLOMSBTvDLt5lKA3VARje0jx+wU9YThSpArVSV/CaZSROocgFn9faLlrmJNky/FB8XIWmQIfLh5t1zwf/zBJ/fJzNhLBJ5h8Kh/xIW6gKm2S+22Ry2FB2XWY3CBtNNpRt1SoJ//TUMXmrOMrHFt4ZIjWhPmMCnyqnoKXOusoVKF/oeOr4tfQsvqNkkeFVRloRKYKvC9Ml8OGNmsT6ULmAH3AHcMq6g79pQoLvQQTIPkT/YsenABLs2OcMb7TKHOcBjbMK9flog2OhvTSMWixCTPSEgpDwMhbi72F2QARgW2TFu4VjJReenFcQoyDizhbT78JNMYox/wzhTJpvKZ9Ehe0QZqIogkWqyPIKK0BpSrjWUhxFMDGBXlKbbPmJWJ6VJl/iPIa5dP9x/qvR87zJx1QdhvgAOz2FqgLtMvbW1g67WqusBAXsS0UnED8tLtkcaZX+aeqLLoc4co50iNb/d4Dd/sl0gdyrzcajiXfo7Vbix/BnAU6loyhdqvBGB/7Tdzx/bDd4JO4TTI/U0/1MdB+Oq3ifWId4t0cNeB/aF8K7o/D+O1nHQUdQX5zCQZTCEFurFjKigRny8GUDumEr/f+EIQwIFvDGMuoo0Awo3osbNm7rhSvC64ITHBtaxVVVPR74wP88ShLIXqJcvJIS8olsoFKl2wTnPwG6RS2kpPxgbgfpC4//vjvSvfMhvX4L9CbE286DPZ+cE/HWwp8/zHvEXw7xw4YI/joQ/9/cwHZBdLjTzEnaimg+n7fiwiIeR4rTRAMXCC6oU6SJggTFG0HlNUpzVjCX4nWc6xbeNGdvhKcfEyK73TztoGWRESpIm1dJWwOmN/NGvt8EvtGc/3agNI+QGPKb3Zqnpe+D0X0mhr7dxNkaPg9w2QbBq+CdQFud+FWvdo7MhV0Dn90APqsJfOMPBt8UsSBqYt+MbDJwzHy0N0ezrVj8DYqsRK3blMUig8HL4nODC7PtMollcmImIuIVhMMib8GTizp/oW3Mimg0oFhFxTKLcccfCfTR6fvS9KxEnFwoaeA508Un+7SI0mviqm2NvdmkDygvF1COrjZnIB4UPFLycl62fsbyjj7VbCy4qOG6omRTBJVzxNCzTg7X8Ck1FEQzoCjnrUwTy1PCfk/W2yGrZ/Vk7cl66rO2WyGr+XDNmslHu+SskP2LxgqRFG7RUSBnJl8zw/O7+iGZQU+xKkXd9fNnZuajujJyjeAlEXbRFi5PmVqA0CP2hhA77BHbI/Y8wavnXhdiS3Q+4USQKY/irJWSDnDLepR38QNjTcGThCHFbEvTvJr8LMF4Z7D1juJVKwPftN6Lf05WExbE7G7h47ElFDPrhDKWRwOs2UoXw5r43bzGrh1r406s4TQUC6rgSHyCX/iKkM5HPW2r0CSG9NJQzjOw/YmvYpF22te14WQpKqCXph2SCyzpKoyEKUSZKfi23WTPqlEARy1RGhySVXxXluR1wxrvYvY3v4xjQx5+1bWC9/PdQK87g4O9cWCsZZOyFKa1aYkffzVPlrbE0d48qltrhVZOtjTAZj4GohdE15iZbg5uAcPKct9WtN0JhraxjAqcvOBKFZpYpuw/cpdTGver2HTdGg1lY9RFJRAP7AxrhrxhzZDsgQ5DWpGsVjmu6Aj6Fv1yGSCPOJA/83rJBWhlMqAn8PUTuDsr2hP4aAL7ZyOwfwsEfgfgFgttNXHr62mPJa4zrBG3Hsi2EPcaaOoa4a3xuIn3LgS49SW1JV9VGrby9EpmBmTKoARw+31/T9wPIK7fnS3tiXs0cc8G3A/irWaryVu5lPn4iBfi87Hrv1vMO6oheDw6EcF1QxP/5wp6ywTEVJK3IPFrhHnW1h64i11P2ouSdtST9odIWxCywkcjPn0LIgtuG9Q28hbHg/vk2FbLjmetZWlm671g70beoePdj6zyp1buxD2Nw/XNbF49pv4BDsPsQXtDQ6Xs25tYW502cqzOuh/oTyr68EbW4GqcwrCamlYLJXoXcEEX0L0MtncBP22wLTeUnOgAPiCytusB8amRdbFi4gaSG3aZKv5DpzUe9RIwmTMW0Hzq08IX5mb/YO4X5abbwE1NnItwc3wubtYMOZPb4eYTRuXWhkFt6W3PyQtysn989otyUjPR5OT4gg/P/NpC2pMfntUNHZsxuAZOihW0PSevj5Pj/qHXWTipyfi1wsybW+d1SVB6kxoonRNBWTc0PjKgfGva9OCG3+tOm9b1Xb9b363p69USH5dmLTdZ8I1jrd9deeq+CrETTex/ENwpVkeYm87Kr0GwxAYP4TP6r5+5pT0S436PxK+8R+JgQ0SDZzp6G9pH7pGAw/LrhSVfyy9pdhb/Aw==&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <rect x="0" y="240" width="730" height="460" rx="10" ry="10" fill="none" stroke="#808080" stroke-dasharray="8 4" pointer-events="none"/>
@@ -90,39 +90,6 @@
                 </foreignObject>
                 <text x="250" y="103" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
                     Layer 3 - Logic...
-                </text>
-            </switch>
-        </g>
-        <path d="M 450 775 C 450 766.72 503.73 760 570 760 C 601.83 760 632.35 761.58 654.85 764.39 C 677.36 767.21 690 771.02 690 775 L 690 865 C 690 873.28 636.27 880 570 880 C 503.73 880 450 873.28 450 865 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
-        <path d="M 690 775 C 690 783.28 636.27 790 570 790 C 503.73 790 450 783.28 450 775" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
-        <g transform="translate(-0.5 -0.5)">
-            <switch>
-                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 833px; margin-left: 451px;">
-                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
-                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
-                                <font style="font-size: 16px">
-                                    <b>
-                                        Datastore
-                                    </b>
-                                </font>
-                                <div>
-                                    [Container : local-files]
-                                </div>
-                                <br/>
-                                <div>
-                                    <font style="font-size: 11px">
-                                        <font color="#E6E6E6">
-                                            Stores all events for the registry in batches.
-                                        </font>
-                                    </font>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </foreignObject>
-                <text x="570" y="836" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
-                    Datastore...
                 </text>
             </switch>
         </g>
@@ -404,12 +371,12 @@
                 </text>
             </switch>
         </g>
-        <path d="M 570 400 L 570 741.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 570 757.76 L 564.67 741.76 L 575.33 741.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 570 400 L 570 511.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 570 527.76 L 564.67 511.76 L 575.33 511.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 580px; margin-left: 570px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 465px; margin-left: 570px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 <div style="text-align: left ; font-size: 11px">
@@ -423,17 +390,17 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="570" y="583" fill="#808080" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                <text x="570" y="468" fill="#808080" font-family="Helvetica" font-size="11px" text-anchor="middle">
                     Reads event and batch
                 </text>
             </switch>
         </g>
-        <path d="M 370 340 L 410 340 L 410 480 L 534 743.5" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
-        <path d="M 540.81 757.98 L 529.17 745.77 L 538.83 741.23 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 370 340 L 410 340 L 410 450 L 510 500 L 510 511.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="none"/>
+        <path d="M 510 527.76 L 504.67 511.76 L 515.33 511.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
         <g transform="translate(-0.5 -0.5)">
             <switch>
                 <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
-                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 539px; margin-left: 438px;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 446px; margin-left: 410px;">
                         <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
                             <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
                                 <div style="text-align: left ; font-size: 11px">
@@ -447,8 +414,38 @@
                         </div>
                     </div>
                 </foreignObject>
-                <text x="438" y="542" fill="#808080" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                <text x="410" y="449" fill="#808080" font-family="Helvetica" font-size="11px" text-anchor="middle">
                     Write event and batch
+                </text>
+            </switch>
+        </g>
+        <rect x="450" y="530" width="240" height="120" fill="#63bef2" stroke="#2086c9" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 590px; margin-left: 451px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Datastore
+                                    </b>
+                                </font>
+                                <div>
+                                    [Component: ]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        Stores all events for the registry in batches.
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="570" y="594" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Datastore...
                 </text>
             </switch>
         </g>

--- a/src/ProjectOrigin.RequestProcessor.Tests/ExampleChat/Chat.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/ExampleChat/Chat.cs
@@ -1,0 +1,19 @@
+using ProjectOrigin.RequestProcessor.Interfaces;
+
+namespace ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+
+public class Chat : IModel, IModelProjectable<ChatCreatedEvent>, IModelProjectable<MessagePostedEvent>
+{
+    public static Chat? Null
+    {
+        get
+        {
+            return null;
+        }
+    }
+
+    public List<object> Events { get; } = new();
+
+    public void Apply(MessagePostedEvent e) => Events.Add(e);
+    public void Apply(ChatCreatedEvent e) => Events.Add(e);
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/ExampleChat/Requests/MessagePosted.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/ExampleChat/Requests/MessagePosted.cs
@@ -1,0 +1,19 @@
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.RequestProcessor.Models;
+
+namespace ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+
+public record MessagePostedEvent(Guid topic, string message);
+
+public record MessagePostedRequest(FederatedStreamId id, MessagePostedEvent e) : PublishRequest<MessagePostedEvent>(id, new byte[0], e);
+
+public class MessagePostedVerifier : IRequestVerifier<MessagePostedRequest, Chat>
+{
+    public Task<VerificationResult> Verify(MessagePostedRequest request, Chat? model)
+    {
+        if (model == null)
+            return VerificationResult.Invalid("Invalid request, chat must exist to post message.");
+
+        return VerificationResult.Valid;
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/ExampleChat/Requests/ThreadCreated.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/ExampleChat/Requests/ThreadCreated.cs
@@ -1,0 +1,19 @@
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.RequestProcessor.Models;
+
+namespace ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+
+public record ChatCreatedEvent(Guid topic);
+
+public record ChatCreatedRequest(FederatedStreamId id, ChatCreatedEvent e) : PublishRequest<ChatCreatedEvent>(id, new byte[0], e);
+
+public class ChatCreatedVerifier : IRequestVerifier<ChatCreatedRequest, Chat>
+{
+    public Task<VerificationResult> Verify(ChatCreatedRequest request, Chat? model)
+    {
+        if (model != null)
+            return VerificationResult.Invalid("Invalid request, chat already exists.");
+
+        return VerificationResult.Valid;
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/ProjectOrigin.RequestProcessor.Tests.csproj
+++ b/src/ProjectOrigin.RequestProcessor.Tests/ProjectOrigin.RequestProcessor.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+	  <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectOrigin.RequestProcessor\ProjectOrigin.RequestProcessor.csproj" />
+    <ProjectReference Include="..\ProjectOrigin.PedersenCommitment\ProjectOrigin.PedersenCommitment.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ProjectOrigin.RequestProcessor.Tests/Services/DispatcherTests.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Services/DispatcherTests.cs
@@ -1,0 +1,58 @@
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.RequestProcessor.Services;
+using ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+
+namespace ProjectOrigin.Services.Tests;
+
+public class DispatcherTests
+{
+    [Fact]
+    public async Task Dispatcher_MessagesInSequence_Success()
+    {
+        var verifiers = new List<Type>(){
+            typeof(ChatCreatedVerifier),
+            typeof(MessagePostedVerifier)
+        };
+
+        var modelLoaderMock = new Mock<IModelLoader>();
+        modelLoaderMock.SetupSequence(obj => obj.Get(It.IsAny<Guid>(), It.IsAny<Type>()))
+            .ReturnsAsync((Chat.Null, 0))
+            .ReturnsAsync((new Chat(), 1));
+
+        var dispatcher = new Dispatcher(verifiers, modelLoaderMock.Object);
+
+        var topicId = Guid.NewGuid();
+
+        var (result1, index1) = await dispatcher.Verify(new ChatCreatedRequest(new FederatedStreamId("", topicId), new ChatCreatedEvent(topicId)));
+        Assert.True(result1.IsValid);
+        Assert.Equal(0, index1);
+
+        var (result2, index2) = await dispatcher.Verify(new MessagePostedRequest(new FederatedStreamId("", topicId), new MessagePostedEvent(topicId, "hello world")));
+        Assert.True(result2.IsValid);
+        Assert.Equal(1, index2);
+    }
+
+    [Fact]
+    public async Task Dispatcher_VerifyFails_ThrowsException()
+    {
+        var verifiers = new List<Type>(){
+            typeof(ChatCreatedVerifier),
+            typeof(MessagePostedVerifier)
+        };
+
+        var modelLoaderMock = new Mock<IModelLoader>();
+        modelLoaderMock.SetupSequence(obj => obj.Get(It.IsAny<Guid>(), It.IsAny<Type>()))
+            .ReturnsAsync((Chat.Null, 0))
+            .ReturnsAsync((new Chat(), 1));
+
+        var dispatcher = new Dispatcher(verifiers, modelLoaderMock.Object);
+
+        var topicId = Guid.NewGuid();
+
+        var (result, index) = await dispatcher.Verify(new MessagePostedRequest(new FederatedStreamId("", topicId), new MessagePostedEvent(topicId, "hello world")));
+
+        Assert.False(result.IsValid);
+        Assert.NotNull(result.ErrorMessage);
+        Assert.Equal("Invalid request, chat must exist to post message.", result.ErrorMessage);
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/Services/DispatcherTests.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Services/DispatcherTests.cs
@@ -15,7 +15,7 @@ public class DispatcherTests
         };
 
         var modelLoaderMock = new Mock<IModelLoader>();
-        modelLoaderMock.SetupSequence(obj => obj.Get(It.IsAny<Guid>(), It.IsAny<Type>()))
+        modelLoaderMock.SetupSequence(obj => obj.Get(It.IsAny<FederatedStreamId>(), It.IsAny<Type>()))
             .ReturnsAsync((Chat.Null, 0))
             .ReturnsAsync((new Chat(), 1));
 
@@ -41,7 +41,7 @@ public class DispatcherTests
         };
 
         var modelLoaderMock = new Mock<IModelLoader>();
-        modelLoaderMock.SetupSequence(obj => obj.Get(It.IsAny<Guid>(), It.IsAny<Type>()))
+        modelLoaderMock.SetupSequence(obj => obj.Get(It.IsAny<FederatedStreamId>(), It.IsAny<Type>()))
             .ReturnsAsync((Chat.Null, 0))
             .ReturnsAsync((new Chat(), 1));
 

--- a/src/ProjectOrigin.RequestProcessor.Tests/Services/JsonSerializerTests.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Services/JsonSerializerTests.cs
@@ -1,0 +1,28 @@
+using ProjectOrigin.RequestProcessor.Services;
+using ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.Services.Tests;
+
+public class JsonEventSerializerTests
+{
+    [Fact]
+    public void JsonEventSerializer_Success()
+    {
+        var fixture = new Fixture();
+
+        var eventId = fixture.Create<EventId>();
+        var eventInput = fixture.Create<MessagePostedEvent>();
+
+        var serializer = new JsonEventSerializer();
+
+        var serializedEvent = serializer.Serialize(eventId, eventInput);
+
+        var deserializedObject = serializer.Deserialize(serializedEvent);
+
+        Assert.IsType<MessagePostedEvent>(deserializedObject);
+
+        var eventOutput = deserializedObject as MessagePostedEvent;
+        Assert.Equal(eventInput, eventOutput);
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/Services/ModelLoaderTests.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Services/ModelLoaderTests.cs
@@ -1,0 +1,54 @@
+using ProjectOrigin.RequestProcessor.Services;
+using ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+using ProjectOrigin.VerifiableEventStore.Models;
+using ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+namespace ProjectOrigin.Services.Tests;
+
+public class ModelLoaderTests
+{
+    [Fact]
+    public async Task ModelLoader_GetDummyChat_Success()
+    {
+        var fixture = new Fixture();
+        var eventStreamId = Guid.NewGuid();
+        var serializer = new JsonEventSerializer();
+
+        var events = new List<Event>(){
+            serializer.Serialize(new(eventStreamId, 0), fixture.Create<ChatCreatedEvent>()),
+            serializer.Serialize(new(eventStreamId, 1), fixture.Create<MessagePostedEvent>()),
+            serializer.Serialize(new(eventStreamId, 2), fixture.Create<MessagePostedEvent>())
+        };
+
+        var eventStoreMock = new Mock<IEventStore>();
+        eventStoreMock.Setup(obj => obj.GetEventsForEventStream(It.IsAny<Guid>())).ReturnsAsync(events);
+
+        var modelLoader = new ModelLoader(eventStoreMock.Object, new JsonEventSerializer());
+
+        var (chat, count) = await modelLoader.Get(eventStreamId, typeof(Chat));
+
+        Assert.IsType<Chat>(chat);
+        var dummyChat = chat as Chat;
+        Assert.Equal(events.Count(), count);
+        Assert.Equal(events.Count(), dummyChat!.Events.Count);
+    }
+
+    [Fact]
+    public async Task ModelLoader_NoEvents_ReturnsNull()
+    {
+        var fixture = new Fixture();
+        var eventStreamId = Guid.NewGuid();
+        var serializer = new JsonEventSerializer();
+
+        var events = new List<Event>();
+
+        var eventStoreMock = new Mock<IEventStore>();
+        eventStoreMock.Setup(obj => obj.GetEventsForEventStream(It.IsAny<Guid>())).ReturnsAsync(events);
+
+        var modelLoader = new ModelLoader(eventStoreMock.Object, new JsonEventSerializer());
+
+        var (chat, count) = await modelLoader.Get(eventStreamId, typeof(Chat));
+
+        Assert.Null(chat);
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/Services/ProjectorTests.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Services/ProjectorTests.cs
@@ -1,0 +1,43 @@
+using ProjectOrigin.RequestProcessor.Services;
+using ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+
+namespace ProjectOrigin.Services.Tests;
+
+public class ProjectorTests
+{
+    [Fact]
+    public void Projector_ProjectEvents_Success()
+    {
+        var fixture = new Fixture();
+        var projector = new Projector(typeof(Chat));
+
+        var events = new List<object>(){
+            fixture.Create<ChatCreatedEvent>(),
+            fixture.Create<MessagePostedEvent>(),
+            fixture.Create<MessagePostedEvent>()
+        };
+
+        var projection = projector.Project(events);
+
+        Assert.IsType<Chat>(projection);
+        var dummyChat = projection as Chat;
+
+        Assert.Equal(events, dummyChat!.Events);
+    }
+
+    [Fact]
+    public void Projector_ProjectEventsInvalidType_Failure()
+    {
+        var fixture = new Fixture();
+        var projector = new Projector(typeof(Chat));
+
+        var events = new List<object>(){
+            fixture.Create<ChatCreatedEvent>(),
+            fixture.Create<ChatCreatedVerifier>(),
+            fixture.Create<MessagePostedEvent>()
+        };
+
+        var ex = Assert.Throws<NotImplementedException>(() => projector.Project(events));
+        Assert.Equal($"No ”Apply” method implemented on class ”{nameof(Chat)}” for event ”{nameof(ChatCreatedVerifier)}”", ex.Message);
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/Services/SynchronousInMemoryRequestProcessorTests.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Services/SynchronousInMemoryRequestProcessorTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using ProjectOrigin.RequestProcessor.Interfaces;
 using ProjectOrigin.RequestProcessor.Models;
 using ProjectOrigin.RequestProcessor.Services;
@@ -13,15 +14,17 @@ public class SynchronousInMemoryRequestProcessorTests
     public async Task RequestProcessor_QueueRequest_Success()
     {
         var fixture = new Fixture();
-        var request = fixture.Create<ChatCreatedRequest>();
+        var registryName = fixture.Create<string>();
         var index = fixture.Create<int>();
+        var request = NewRequest(registryName);
 
         var serializer = new JsonEventSerializer();
         var batcherMock = new Mock<IBatcher>();
         var dispatcherMock = new Mock<IDispatcher>();
         dispatcherMock.Setup(obj => obj.Verify(It.IsAny<IPublishRequest>())).ReturnsAsync((VerificationResult.Valid, index));
+        var optionsMock = CreateOptionsMock<RequestProcessorOptions>(new RequestProcessorOptions(registryName));
 
-        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+        var processor = new SynchronousInMemoryRequestProcessor(optionsMock, dispatcherMock.Object, batcherMock.Object, serializer);
 
         await processor.QueueRequest(request);
 
@@ -33,11 +36,13 @@ public class SynchronousInMemoryRequestProcessorTests
     {
         var fixture = new Fixture();
 
+        var registryName = fixture.Create<string>();
         var serializer = new JsonEventSerializer();
         var batcherMock = new Mock<IBatcher>();
         var dispatcherMock = new Mock<IDispatcher>();
+        var optionsMock = CreateOptionsMock<RequestProcessorOptions>(new RequestProcessorOptions(registryName));
 
-        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+        var processor = new SynchronousInMemoryRequestProcessor(optionsMock, dispatcherMock.Object, batcherMock.Object, serializer);
 
         var result = await processor.GetRequestStatus(fixture.Create<RequestId>());
 
@@ -48,14 +53,17 @@ public class SynchronousInMemoryRequestProcessorTests
     public async Task RequestProcessor_GetStatus_Success()
     {
         var fixture = new Fixture();
-        var request = fixture.Create<ChatCreatedRequest>();
+        var registryName = fixture.Create<string>();
+        var request = NewRequest(registryName);
 
         var serializer = new JsonEventSerializer();
         var batcherMock = new Mock<IBatcher>();
         var dispatcherMock = new Mock<IDispatcher>();
         dispatcherMock.Setup(obj => obj.Verify(It.IsAny<IPublishRequest>())).ReturnsAsync((VerificationResult.Valid, fixture.Create<int>()));
 
-        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+        var optionsMock = CreateOptionsMock<RequestProcessorOptions>(new RequestProcessorOptions(registryName));
+
+        var processor = new SynchronousInMemoryRequestProcessor(optionsMock, dispatcherMock.Object, batcherMock.Object, serializer);
         await processor.QueueRequest(request);
 
         var result = await processor.GetRequestStatus(request.RequestId);
@@ -67,15 +75,18 @@ public class SynchronousInMemoryRequestProcessorTests
     public async Task RequestProcessor_GetStatus_Error()
     {
         var fixture = new Fixture();
-        var request = fixture.Create<ChatCreatedRequest>();
+        var registryName = fixture.Create<string>();
+        var request = NewRequest(registryName);
+
         var errorMessage = fixture.Create<string>();
 
         var serializer = new JsonEventSerializer();
         var batcherMock = new Mock<IBatcher>();
         var dispatcherMock = new Mock<IDispatcher>();
         dispatcherMock.Setup(obj => obj.Verify(It.IsAny<IPublishRequest>())).ReturnsAsync((VerificationResult.Invalid(errorMessage), fixture.Create<int>()));
+        var optionsMock = CreateOptionsMock<RequestProcessorOptions>(new RequestProcessorOptions(registryName));
 
-        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+        var processor = new SynchronousInMemoryRequestProcessor(optionsMock, dispatcherMock.Object, batcherMock.Object, serializer);
         await processor.QueueRequest(request);
 
         var result = await processor.GetRequestStatus(request.RequestId);
@@ -83,4 +94,34 @@ public class SynchronousInMemoryRequestProcessorTests
         Assert.Equal(RequestState.Failed, result.State);
         Assert.Equal(errorMessage, result.ErrorMessage);
     }
+
+    [Fact]
+    public async Task RequestProcessor_InvalidRegistry_ThrowsException()
+    {
+        var fixture = new Fixture();
+        var registryName = fixture.Create<string>();
+        var otherRegistryName = fixture.Create<string>();
+        var request = NewRequest(otherRegistryName);
+        var errorMessage = fixture.Create<string>();
+
+        var serializer = new JsonEventSerializer();
+        var batcherMock = new Mock<IBatcher>();
+        var dispatcherMock = new Mock<IDispatcher>();
+        dispatcherMock.Setup(obj => obj.Verify(It.IsAny<IPublishRequest>())).ReturnsAsync((VerificationResult.Valid, 0));
+        var optionsMock = CreateOptionsMock<RequestProcessorOptions>(new RequestProcessorOptions(registryName));
+
+        var processor = new SynchronousInMemoryRequestProcessor(optionsMock, dispatcherMock.Object, batcherMock.Object, serializer);
+        var ex = await Assert.ThrowsAsync<InvalidDataException>(() => processor.QueueRequest(request));
+
+        Assert.Equal("Invalid registry for request", ex.Message);
+    }
+
+    private IOptions<T> CreateOptionsMock<T>(T content) where T : class
+    {
+        var optionsMock = new Mock<IOptions<T>>();
+        optionsMock.Setup(obj => obj.Value).Returns(content);
+        return optionsMock.Object;
+    }
+
+    private static ChatCreatedRequest NewRequest(string registry) => new ChatCreatedRequest(new(registry, Guid.NewGuid()), new(Guid.NewGuid()));
 }

--- a/src/ProjectOrigin.RequestProcessor.Tests/Services/SynchronousInMemoryRequestProcessorTests.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Services/SynchronousInMemoryRequestProcessorTests.cs
@@ -1,0 +1,86 @@
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.RequestProcessor.Models;
+using ProjectOrigin.RequestProcessor.Services;
+using ProjectOrigin.RequestProcessor.Tests.ExampleChat;
+using ProjectOrigin.VerifiableEventStore.Models;
+using ProjectOrigin.VerifiableEventStore.Services.Batcher;
+
+namespace ProjectOrigin.Services.Tests;
+
+public class SynchronousInMemoryRequestProcessorTests
+{
+    [Fact]
+    public async Task RequestProcessor_QueueRequest_Success()
+    {
+        var fixture = new Fixture();
+        var request = fixture.Create<ChatCreatedRequest>();
+        var index = fixture.Create<int>();
+
+        var serializer = new JsonEventSerializer();
+        var batcherMock = new Mock<IBatcher>();
+        var dispatcherMock = new Mock<IDispatcher>();
+        dispatcherMock.Setup(obj => obj.Verify(It.IsAny<IPublishRequest>())).ReturnsAsync((VerificationResult.Valid, index));
+
+        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+
+        await processor.QueueRequest(request);
+
+        batcherMock.Verify(obj => obj.PublishEvent(It.Is<Event>(e => e.Id == new EventId(request.FederatedStreamId.StreamId, index))), Times.Once);
+    }
+
+    [Fact]
+    public async Task RequestProcessor_GetStatus_Unknown()
+    {
+        var fixture = new Fixture();
+
+        var serializer = new JsonEventSerializer();
+        var batcherMock = new Mock<IBatcher>();
+        var dispatcherMock = new Mock<IDispatcher>();
+
+        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+
+        var result = await processor.GetRequestStatus(fixture.Create<RequestId>());
+
+        Assert.Equal(RequestState.Unknown, result.State);
+    }
+
+    [Fact]
+    public async Task RequestProcessor_GetStatus_Success()
+    {
+        var fixture = new Fixture();
+        var request = fixture.Create<ChatCreatedRequest>();
+
+        var serializer = new JsonEventSerializer();
+        var batcherMock = new Mock<IBatcher>();
+        var dispatcherMock = new Mock<IDispatcher>();
+        dispatcherMock.Setup(obj => obj.Verify(It.IsAny<IPublishRequest>())).ReturnsAsync((VerificationResult.Valid, fixture.Create<int>()));
+
+        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+        await processor.QueueRequest(request);
+
+        var result = await processor.GetRequestStatus(request.RequestId);
+
+        Assert.Equal(RequestState.Completed, result.State);
+    }
+
+    [Fact]
+    public async Task RequestProcessor_GetStatus_Error()
+    {
+        var fixture = new Fixture();
+        var request = fixture.Create<ChatCreatedRequest>();
+        var errorMessage = fixture.Create<string>();
+
+        var serializer = new JsonEventSerializer();
+        var batcherMock = new Mock<IBatcher>();
+        var dispatcherMock = new Mock<IDispatcher>();
+        dispatcherMock.Setup(obj => obj.Verify(It.IsAny<IPublishRequest>())).ReturnsAsync((VerificationResult.Invalid(errorMessage), fixture.Create<int>()));
+
+        var processor = new SynchronousInMemoryRequestProcessor(dispatcherMock.Object, batcherMock.Object, serializer);
+        await processor.QueueRequest(request);
+
+        var result = await processor.GetRequestStatus(request.RequestId);
+
+        Assert.Equal(RequestState.Failed, result.State);
+        Assert.Equal(errorMessage, result.ErrorMessage);
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor.Tests/Usings.cs
+++ b/src/ProjectOrigin.RequestProcessor.Tests/Usings.cs
@@ -1,0 +1,3 @@
+global using AutoFixture;
+global using Moq;
+global using Xunit;

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IDispatcher.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IDispatcher.cs
@@ -1,0 +1,8 @@
+using ProjectOrigin.RequestProcessor.Models;
+
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IDispatcher
+{
+    Task<(VerificationResult Result, int NextEventIndex)> Verify(IPublishRequest request);
+}

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IEventSerializer.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IEventSerializer.cs
@@ -1,0 +1,12 @@
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IEventSerializer
+{
+    object Deserialize(Event e);
+
+    Event Serialize(EventId id, object e);
+
+    byte[] Serialize(object e);
+}

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IModel.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IModel.cs
@@ -1,0 +1,5 @@
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IModel
+{
+}

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IModelLoader.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IModelLoader.cs
@@ -2,5 +2,6 @@ namespace ProjectOrigin.RequestProcessor.Interfaces;
 
 public interface IModelLoader
 {
-    Task<(IModel? model, int eventCount)> Get(Guid eventStreamId, Type type);
+    Task<(T? model, int eventCount)> Get<T>(FederatedStreamId eventStreamId) where T : class, IModel;
+    Task<(IModel? model, int eventCount)> Get(FederatedStreamId eventStreamId, Type type);
 }

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IModelLoader.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IModelLoader.cs
@@ -1,0 +1,6 @@
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IModelLoader
+{
+    Task<(IModel? model, int eventCount)> Get(Guid eventStreamId, Type type);
+}

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IModelProjectable.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IModelProjectable.cs
@@ -1,0 +1,6 @@
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IModelProjectable<T>
+{
+    void Apply(T e);
+}

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IProjector.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IProjector.cs
@@ -1,0 +1,6 @@
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IProjector
+{
+    IModel Project(IEnumerable<object> events);
+}

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IRequestProcessor.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IRequestProcessor.cs
@@ -1,0 +1,9 @@
+using ProjectOrigin.RequestProcessor.Models;
+
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IRequestProcessor
+{
+    Task QueueRequest(IPublishRequest request);
+    Task<RequestResult> GetRequestStatus(RequestId id);
+}

--- a/src/ProjectOrigin.RequestProcessor/Interfaces/IRequestVerifier.cs
+++ b/src/ProjectOrigin.RequestProcessor/Interfaces/IRequestVerifier.cs
@@ -1,0 +1,8 @@
+using ProjectOrigin.RequestProcessor.Models;
+
+namespace ProjectOrigin.RequestProcessor.Interfaces;
+
+public interface IRequestVerifier<TRequest, TModel> where TRequest : PublishRequest
+{
+    Task<VerificationResult> Verify(TRequest request, TModel? model);
+}

--- a/src/ProjectOrigin.RequestProcessor/Models/Context.cs
+++ b/src/ProjectOrigin.RequestProcessor/Models/Context.cs
@@ -1,0 +1,5 @@
+using ProjectOrigin.PedersenCommitment;
+
+namespace ProjectOrigin.RequestProcessor.Models;
+
+public record Context(Group Group);

--- a/src/ProjectOrigin.RequestProcessor/Models/FederatedStreamId.cs
+++ b/src/ProjectOrigin.RequestProcessor/Models/FederatedStreamId.cs
@@ -1,0 +1,4 @@
+
+public record FederatedStreamId(
+    string Registry,
+    Guid StreamId);

--- a/src/ProjectOrigin.RequestProcessor/Models/PublishRequest.cs
+++ b/src/ProjectOrigin.RequestProcessor/Models/PublishRequest.cs
@@ -1,0 +1,43 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using ProjectOrigin.RequestProcessor.Services.Serialization;
+
+namespace ProjectOrigin.RequestProcessor.Models;
+
+public abstract record PublishRequest<T>(FederatedStreamId FederatedStreamId, byte[] Signature, T Event) : PublishRequest(FederatedStreamId, Signature, Event) where T : class
+{
+    public new T Event
+    {
+        get
+        {
+            return (T)base.Event;
+        }
+        init
+        {
+            base.Event = value ?? throw new Exception("Must be set to an instance of an object");
+        }
+    }
+}
+
+public abstract record PublishRequest(FederatedStreamId FederatedStreamId, byte[] Signature, object Event) : IPublishRequest
+{
+    public RequestId RequestId
+    {
+        get
+        {
+            var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+            options.Converters.Add(new BigIntegerConverter());
+            var json = JsonSerializer.Serialize(new { FederatedStreamId, Signature, Event }, options);
+            var hash = SHA256.HashData(Encoding.UTF8.GetBytes(json));
+            return new RequestId(hash);
+        }
+    }
+}
+
+public interface IPublishRequest
+{
+    object Event { get; }
+    FederatedStreamId FederatedStreamId { get; }
+    RequestId RequestId { get; }
+}

--- a/src/ProjectOrigin.RequestProcessor/Models/RequestId.cs
+++ b/src/ProjectOrigin.RequestProcessor/Models/RequestId.cs
@@ -1,0 +1,21 @@
+namespace ProjectOrigin.RequestProcessor.Models;
+
+public record RequestId(byte[] RequestHash)
+{
+    public virtual bool Equals(RequestId? other)
+    {
+        if (other is null) return false;
+
+        return RequestHash.SequenceEqual(other!.RequestHash);
+    }
+
+    public override int GetHashCode()
+    {
+        var hc = RequestHash.Length;
+        foreach (int val in RequestHash)
+        {
+            hc = unchecked(hc * 314159 + val);
+        }
+        return hc;
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor/Models/RequestResult.cs
+++ b/src/ProjectOrigin.RequestProcessor/Models/RequestResult.cs
@@ -1,0 +1,3 @@
+namespace ProjectOrigin.RequestProcessor.Models;
+
+public record RequestResult(RequestId Id, RequestState State, string? ErrorMessage = null);

--- a/src/ProjectOrigin.RequestProcessor/Models/RequestState.cs
+++ b/src/ProjectOrigin.RequestProcessor/Models/RequestState.cs
@@ -1,0 +1,10 @@
+namespace ProjectOrigin.RequestProcessor.Models;
+
+public enum RequestState
+{
+    Failed,
+    Unknown,
+    Queued,
+    Processing,
+    Completed,
+}

--- a/src/ProjectOrigin.RequestProcessor/Models/VerificationResult.cs
+++ b/src/ProjectOrigin.RequestProcessor/Models/VerificationResult.cs
@@ -1,0 +1,9 @@
+namespace ProjectOrigin.RequestProcessor.Models;
+
+public record VerificationResult(bool IsValid, string? ErrorMessage)
+{
+    public static VerificationResult Valid { get => new VerificationResult(true, null); }
+    public static VerificationResult Invalid(string error) => new VerificationResult(false, error);
+
+    public static implicit operator Task<VerificationResult>(VerificationResult result) => Task.FromResult(result);
+}

--- a/src/ProjectOrigin.RequestProcessor/ProjectOrigin.RequestProcessor.csproj
+++ b/src/ProjectOrigin.RequestProcessor/ProjectOrigin.RequestProcessor.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectOrigin.VerifiableEventStore\ProjectOrigin.VerifiableEventStore.csproj" />
+    <ProjectReference Include="..\ProjectOrigin.PedersenCommitment\ProjectOrigin.PedersenCommitment.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/src/ProjectOrigin.RequestProcessor/README.md
+++ b/src/ProjectOrigin.RequestProcessor/README.md
@@ -1,0 +1,45 @@
+# Layer 4 - Privacy
+
+![C4 component diagram of layer 4](/doc/layer4_privacy/component_diagra.drawio.svg)
+
+## Requests
+
+### IssueProduction
+Role: IssuingBody
+RequestBody: {m, r, from, to, gridArea, productionType..., publicM: bool }
+
+### IssueConsumption
+Role: IssuingBody
+RequestBody: {m, r, from, to, gridArea, }
+
+### TransferOwnership
+Role: Owner
+RequestBody: {m, r_transfer, r_remainer}
+
+
+```protobuf
+message IssueProduction {
+  required int64 m = 1; // quantity to transfer
+  required bytes r_transfer = 2; // r to hide transfer quantity behind
+  required bytes r_remainer = 3; // r to hide remainder behind
+}
+```
+
+
+### AllocateProductionClaim
+Role: Owner
+Description: Allocate part of a production certificate for a claim flow.
+RequestBody: {m, r_claim, r_remainer, consumptionEventId, productionEventId, ref1, ref2}
+
+### ClaimToConsumption
+Role: Owner
+Description: Initiate claim to a consumption certificate as part of claim flow.
+RequestBody: {m, r_claim, r_remainer, consumptionEventId, productionEventId, ref1, ref2}
+
+### ProductionClaimCommit
+Role: Registry
+RequestBody: {ref1, ref2}
+
+### ConsumptionClaimCommit
+Role: Registry
+RequestBody: {ref2, ref3}

--- a/src/ProjectOrigin.RequestProcessor/Services/Dispatcher.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/Dispatcher.cs
@@ -40,7 +40,7 @@ public class Dispatcher : IDispatcher
 
         var func = async (IPublishRequest request, IModelLoader ml) =>
         {
-            var (model, eventCount) = await ml.Get(request.FederatedStreamId.StreamId, modelType);
+            var (model, eventCount) = await ml.Get(request.FederatedStreamId, modelType);
 
             var result = await (methodInfo.Invoke(verifier, new object[]{
                 request, model!

--- a/src/ProjectOrigin.RequestProcessor/Services/Dispatcher.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/Dispatcher.cs
@@ -1,0 +1,54 @@
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.RequestProcessor.Models;
+
+namespace ProjectOrigin.RequestProcessor.Services;
+
+public class Dispatcher : IDispatcher
+{
+    private IModelLoader modelLoader;
+    private Dictionary<Type, Func<IPublishRequest, IModelLoader, Task<(VerificationResult, int)>>> verifierDictionary;
+
+    public Dispatcher(IEnumerable<Type> verifiers, IModelLoader modelLoader)
+    {
+        verifierDictionary = verifiers.Select(v => GetVerifyFunction(v)).ToDictionary(res => res.requestType, res => res.function);
+        this.modelLoader = modelLoader;
+    }
+
+    public Task<(VerificationResult Result, int NextEventIndex)> Verify(IPublishRequest request)
+    {
+        var requestType = request.GetType();
+
+        var verifier = verifierDictionary[requestType];
+
+        return verifier(request, modelLoader);
+    }
+
+    static readonly Type genericInterfaceType = typeof(IRequestVerifier<,>);
+
+    private (Type requestType, Func<IPublishRequest, IModelLoader, Task<(VerificationResult, int)>> function) GetVerifyFunction(Type verifierType)
+    {
+        var interfaceType = verifierType.GetInterfaces().Single(i => i.GetGenericTypeDefinition() == genericInterfaceType);
+        var argumentTypes = interfaceType.GetGenericArguments();
+
+        var requestType = argumentTypes[0];
+        var modelType = argumentTypes[1];
+
+        var methodInfo = interfaceType.GetMethod(nameof(IRequestVerifier<PublishRequest, object>.Verify)) ?? throw new InvalidOperationException("IRequestVerifier does not have a verify method");
+        if (methodInfo.ReturnType != typeof(Task<VerificationResult>)) throw new InvalidOperationException("Verify does not return Task");
+
+        var verifier = Activator.CreateInstance(verifierType);
+
+        var func = async (IPublishRequest request, IModelLoader ml) =>
+        {
+            var (model, eventCount) = await ml.Get(request.FederatedStreamId.StreamId, modelType);
+
+            var result = await (methodInfo.Invoke(verifier, new object[]{
+                request, model!
+            }) as Task<VerificationResult>)!;
+
+            return (result, eventCount);
+        };
+
+        return (requestType, func);
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor/Services/JsonEventSerializer.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/JsonEventSerializer.cs
@@ -1,0 +1,78 @@
+using System.Text;
+using System.Text.Json;
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.RequestProcessor.Services.Serialization;
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.RequestProcessor.Services;
+
+public class JsonEventSerializer : IEventSerializer
+{
+    private Lazy<JsonSerializerOptions> serializerOptions = new Lazy<JsonSerializerOptions>(() =>
+    {
+        var options = new JsonSerializerOptions(JsonSerializerDefaults.Web);
+        options.Converters.Add(new BigIntegerConverter());
+        return options;
+    });
+
+    public object Deserialize(Event e)
+    {
+        try
+        {
+            return Unwrap(e.Content);
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Could not deserialize Event ”{e.Id}”", ex);
+        }
+    }
+
+    public Event Serialize(EventId id, object e)
+    {
+        try
+        {
+            return new Event(id, Wrap(e));
+        }
+        catch (Exception ex)
+        {
+            throw new Exception($"Could not serialize Event ”{id}”", ex);
+        }
+    }
+
+    public byte[] Serialize(object e)
+    {
+        var json = JsonSerializer.Serialize(e, serializerOptions.Value);
+        return Encoding.UTF8.GetBytes(json);
+    }
+
+    private byte[] Wrap(object o)
+    {
+        var serializedObject = Serialize(o);
+        var eventTypeName = o.GetType().FullName ?? throw new Exception($"No Fullname for type ”{o.GetType().ToString()}”");
+        var internalEvent = new EventWrapper(eventTypeName, serializedObject);
+        return Serialize(internalEvent);
+    }
+
+    private object Unwrap(byte[] bytes)
+    {
+        var wrapper = JsonSerializer.Deserialize<EventWrapper>(bytes, serializerOptions.Value) ?? throw new Exception($"Could deserialize to EventWrapper");
+
+        //TODO optimize!
+        foreach (var a in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            foreach (var t in a.GetTypes())
+            {
+                if (t.FullName == wrapper.EventType)
+                {
+                    var json = Encoding.UTF8.GetString(wrapper.EventBytes);
+                    return JsonSerializer.Deserialize(wrapper.EventBytes, t, serializerOptions.Value) ?? throw new Exception($"Could not deserialize to type {t.Name}");
+                }
+            }
+        }
+
+        throw new Exception($"Type ”{wrapper.EventType}” could not be found.");
+    }
+
+
+    record EventWrapper(string EventType, byte[] EventBytes);
+}

--- a/src/ProjectOrigin.RequestProcessor/Services/ModelLoader.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/ModelLoader.cs
@@ -1,0 +1,41 @@
+using System.Collections.Concurrent;
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+namespace ProjectOrigin.RequestProcessor.Services;
+
+public class ModelLoader : IModelLoader
+{
+    private ConcurrentDictionary<Type, Projector> projectorDictionary;
+    private IEventStore eventStore;
+    private IEventSerializer eventSerializer;
+
+    public ModelLoader(IEventStore eventStore, IEventSerializer eventSerializer)
+    {
+        projectorDictionary = new();
+        this.eventStore = eventStore;
+        this.eventSerializer = eventSerializer;
+    }
+
+    public async Task<(IModel? model, int eventCount)> Get(Guid eventStreamId, Type type)
+    {
+        var projector = GetProjector(type);
+
+        var events = await eventStore.GetEventsForEventStream(eventStreamId);
+
+        if (events.Any())
+        {
+            var deserializedEvents = events.Select(e => eventSerializer.Deserialize(e));
+            return (projector.Project(deserializedEvents), deserializedEvents.Count());
+        }
+        else
+        {
+            return (null, 0);
+        }
+    }
+
+    private IProjector GetProjector(Type type)
+    {
+        return projectorDictionary.GetOrAdd(type, (type) => new Projector(type));
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor/Services/ModelLoaderOptions.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/ModelLoaderOptions.cs
@@ -1,0 +1,5 @@
+using ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+namespace ProjectOrigin.RequestProcessor.Services;
+
+public record ModelLoaderOptions(Dictionary<string, IEventStore> EventStores);

--- a/src/ProjectOrigin.RequestProcessor/Services/Projector.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/Projector.cs
@@ -1,0 +1,40 @@
+using System.Reflection;
+using ProjectOrigin.RequestProcessor.Interfaces;
+
+namespace ProjectOrigin.RequestProcessor.Services;
+
+public class Projector : IProjector
+{
+    private Type type;
+    private Dictionary<Type, MethodInfo> applyDict;
+
+    public Projector(Type type)
+    {
+        this.type = type;
+
+        var methonName = nameof(IModelProjectable<object>.Apply);
+
+        var applyMethods = type.GetMethods().Where(x => x.Name == methonName && x.GetParameters().Count() == 1 && x.ReturnType == typeof(void));
+        applyDict = applyMethods.ToDictionary(m => m.GetParameters().Single().ParameterType);
+    }
+
+    public IModel Project(IEnumerable<object> events)
+    {
+        var obj = Activator.CreateInstance(type) ?? throw new Exception("Type could not be instanciated.");
+
+        foreach (var e in events)
+        {
+            var eventType = e.GetType();
+            if (applyDict.TryGetValue(eventType, out var method))
+            {
+                method.Invoke(obj, new object[] { e });
+            }
+            else
+            {
+                throw new NotImplementedException($"No ”Apply” method implemented on class ”{type.Name}” for event ”{eventType.Name}”");
+            }
+        }
+
+        return (IModel)obj;
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor/Services/RequestProcessorOptions.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/RequestProcessorOptions.cs
@@ -1,0 +1,3 @@
+namespace ProjectOrigin.RequestProcessor.Services;
+
+public record RequestProcessorOptions(string RegistryName);

--- a/src/ProjectOrigin.RequestProcessor/Services/Serialization/BigIntegerConverter.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/Serialization/BigIntegerConverter.cs
@@ -1,0 +1,17 @@
+using System.Numerics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace ProjectOrigin.RequestProcessor.Services.Serialization;
+
+public class BigIntegerConverter : JsonConverter<BigInteger>
+{
+    public override BigInteger Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        return new BigInteger(reader.GetBytesFromBase64());
+    }
+    public override void Write(Utf8JsonWriter writer, BigInteger value, JsonSerializerOptions options)
+    {
+        writer.WriteBase64StringValue(value.ToByteArray());
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor/Services/SynchronousInMemoryRequestProcessor.cs
+++ b/src/ProjectOrigin.RequestProcessor/Services/SynchronousInMemoryRequestProcessor.cs
@@ -1,0 +1,75 @@
+using System.Collections.Concurrent;
+using ProjectOrigin.RequestProcessor.Interfaces;
+using ProjectOrigin.RequestProcessor.Models;
+using ProjectOrigin.VerifiableEventStore.Models;
+using ProjectOrigin.VerifiableEventStore.Services.Batcher;
+
+namespace ProjectOrigin.RequestProcessor.Services;
+
+public class SynchronousInMemoryRequestProcessor : IRequestProcessor
+{
+    private ConcurrentDictionary<RequestId, RequestResult> requestDictionary = new();
+    private IDispatcher dispatcher;
+    private IBatcher batcher;
+    private IEventSerializer eventSerializer;
+
+    public SynchronousInMemoryRequestProcessor(IDispatcher dispatcher, IBatcher batcher, IEventSerializer eventSerializer)
+    {
+        this.dispatcher = dispatcher;
+        this.batcher = batcher;
+        this.eventSerializer = eventSerializer;
+    }
+
+    public async Task QueueRequest(IPublishRequest request)
+    {
+        if (requestDictionary.TryAdd(request.RequestId, new RequestResult(request.RequestId, RequestState.Queued)))
+        {
+            await ProcessRequest(request);
+        }
+        else
+        {
+            throw new ArgumentException($"Request already exists");
+        }
+    }
+
+    public Task<RequestResult> GetRequestStatus(RequestId id)
+    {
+        if (requestDictionary.TryGetValue(id, out var requestStatus))
+        {
+            return Task.FromResult(requestStatus);
+        }
+        else
+        {
+            return Task.FromResult(new RequestResult(id, RequestState.Unknown));
+        }
+    }
+
+    private async Task ProcessRequest(IPublishRequest request)
+    {
+        var (result, nextEventIndex) = await dispatcher.Verify(request);
+
+        if (result.IsValid)
+        {
+            SetState(request.RequestId, RequestState.Processing);
+            var serializedEvent = eventSerializer.Serialize(new EventId(request.FederatedStreamId.StreamId, nextEventIndex), request.Event);
+
+            await batcher.PublishEvent(serializedEvent);
+            SetState(request.RequestId, RequestState.Completed);
+        }
+        else
+        {
+            if (result.ErrorMessage is null)
+                throw new InvalidOperationException("Verification failed without errorMessage!");
+
+            SetState(request.RequestId, RequestState.Failed, result.ErrorMessage);
+        }
+    }
+
+    private void SetState(RequestId id, RequestState state, string? exception = null)
+    {
+        if (requestDictionary.TryGetValue(id, out var oldState))
+        {
+            requestDictionary.TryUpdate(id, new RequestResult(id, state, exception), oldState);
+        }
+    }
+}

--- a/src/ProjectOrigin.RequestProcessor/component_diagra.drawio.svg
+++ b/src/ProjectOrigin.RequestProcessor/component_diagra.drawio.svg
@@ -1,0 +1,567 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1061px" height="921px" viewBox="-0.5 -0.5 1061 921" content="&lt;mxfile&gt;&lt;diagram id=&quot;FBxYk-bCOjcYe218ZED0&quot; name=&quot;Page-1&quot;&gt;7Z3bdqM4FoafJpfO4ox9mVNN1ayamaxOdc/0pQyKrQkgGuQkrqcfHQEJcHzAdlxD1+puI4QQYuvTr60t6sq9S9//VoB8+Q8cw+TKseL3K/f+ynEc2wvp/1jKWqT4oSUSFgWKRZJdJzyhn1AmqmwrFMNSy0gwTgjK9cQIZxmMiJYGigK/6dmecaLfNQcL2Ep4ikDSTv03islSpE6dsE7/CtFiqe5sBzNxJgUqs3yScgli/NZIch+u3LsCYyJ+pe93MGGNp9pFXPel52xVsQJmZJsLHFkNslbPBmP6qPIwwxn93+2SpAk9sunPGJRLGMuDZ5wR+XJsWvNbmMU3rHXp8TzB0YtI+oISdXWBV1nML7fk5Xc4wQW/sTu12B+aXpICv8D+M6rJ+S3fEfkPK+/al0d/ynux3/fv8lb8YN04eIQFSiGBhUrLSLFuFMQO/2yeq4viR+vmkVlY+yXI91LiVREpG/JFGmtv3ZJBsYDyOsevbIJ2JojpXYo1zVPABBD0ql8IpFUvqnzVpY8Y0ao4luyB3tQTl8j+Z08tvQhRB3lV03yMgnzfufZD23Om4r9Gsa5RrHj+VrH0R+Pp6iRuq91264qCX0Gyko3w8A6jFaFUoM2MFhm1Mmb6QUJb8nZe0F8L9ivCaQqyuOTEYDXjjblA1LLW15194TuYU3ppnQAk9Ab0d0TfL3vpt6+wIIji4UaeSFEcszJuC1iin2DOy2OWkbNH543h31759x19KGG3uwXRy4J3FtULZE/crgO17U92c1ZP+N6FSFlHjUKaxcmrJta17QWB9ponsvQDjTKYaqWqOqsC8PNzCQ81GzWAbM27QbmgwfMMsOzlkoYcp5NLgzPIDnRYhN52sGgV5DrT69DXyprO7Gt/K6LRVwDWjWyygx5oZXaLTk8EF5xNFD687QBnUAwII1BeYEI7IWfWfN1NLURSyKsmi8BkSQ2LXYteAYGysF+YYarvDgMxN9TNb2IPAjFbHwAPRxie/5cpWNoUCYjgkipVWBgi1/snSGV9b6KIti7LDua0/4OIIJypbD/Wucz2rxXLgp+ZpUQ4Z8ZTrksCU5X1HpZRgXJ+Nb/iDmcRzKurgLgPtUZaX2tVsjopw2R1RNlCnqOjLVXD7Gy+micomtT2+gLX/BWjorzmg7V8wYmw1nt+JLoCsxLNrIO/VlidmJTc9m5oBjvI3+uTqvtUHapO8GWrMYElTtJ2n5sX0DRxZz05Rq9Vki8K421LC/PvG9c287X6dFdhuz6tvelpZSlR1bnqjG7E/+m61tdfvtY+XW1hPqbT5GBTvUpGNsikg+BtiQh8ygHXx2903qjzajNTnumw2aTI3dSbBW26PPN/uugHikgRrHNUDd0gnDK20Z4KHmJE1CC9EY631jVrwDuL/8ts444ndqWF7USbHakS9MSutNDvKtLuuLeZ5nQkdhbZcW/LqCQfEXqVRgvevZD2DH2g6PBWT7gdJRmWzcm2Y+iIJrQ17taQpYeSs3sw9zc5fWhjlkKTAJTB4olB9pbZLajz3eQ55SHQGCuynw6DDQR1lErfFJnIrsKKTeAz6WFGG6YdXNsVsftXSVK52cQb4axRK9ySWqYLxP6YYtoMoGaOYxkMk1jrF/d9smkzJhX2eKu1Jd8cE4LTqhRcULs3a0QfjQ7uP3AugScTFDjZAz4CQqHKCqQzOsvrgCYmgDSh2ZgnFUzHZYsENiZPoj6PII7FnSz+KAl+u1G+PIuL5KYIFI6enEkScUALXhUlVXa/QdFRRBZaK3mFrfANi4dXKCjO7zQvcbIi8KYeIkbQDwh6u8cX1QB9OA3aoPeDE4P+D2qRz4hbC50eMxPhZKATuw3or07BaJnRvrSQj8m9T3M+bWNGniLusepR39XsEb6qOWCtqKtp5F0lwQGd1WZCddNZYsrglklnF5XqiJ/gOj6FxQv3zZMCQqnYIYiWbCLEfNDyHhRalceMFshqzlwW0RKIcp8Jn4qK8tlVBLHhwMIsNVulc36a31E8wfXlK31eC5FSv9rLmQE8BOzPsWcAWtc/cAZgDrU7zQgc98a5nw05I7Aewvub+3FGcL4ZwfSTTQlq+j/BqOAclP49bZCohwZzpLCGHSxKoxYJeoEcB/3ORJmTLAG7LuVNKO9MZTRc4AKV3Espxh/hyjktzBV/dwZ3o6EFvQOQMsRk8zKvCh9R3otyZyPKyyXg1h+tE0SZXriMmZKf/sdwn4uR4Pu8e/Vjf9Y3/dJbs39r2LfgPjyyhwaxOT4NAebPzeVawd8jOl0l0bIhyxuKPc2pOcnloQ4I01u7vdDlJUdCJr+yecKaIzNJDN0c4aIQFf52J5aixayC0xeleQIZmLnHYtTIxwXroHB0d/AZDenpDtzbhy87sa3WtUEX6RxrGtzNRlm7k6ztWJJsAbWXnr7h53Y/Kz15HN93DOK98AmvF2yV74mKxmzBfsDiFUWwl6i3K5TwNXImSFMZQjgHQn7ibnfG6Fy4OHB6IzhHcO4HTscI4XBnn5WcUuo9FjiCZYkHV58/wAuHYCO6UczrYVaulDPgrxXMIgQSpVCrhTGZV3iTVVqDp1csQprp05KjzuKrI0+kgCAdUXtBqN02GmNE7Yjaj4IxTihS23sWZKBwTxAvLsgSL3AGkoc6VY/pPf02BRVGXMUU8yDiOqZ4lzDias/DVb3jod7/sP2eB9GKrf0HH+xbcGRgrRYz7HZbz6HbFMwB3jaMadsQYds2Fpk9M9j4lOHBjtwM1AgP/r3kg3Tc8E8JrxE1RR4r2R51mHNJ5aq9Sq/Sm/SLxQFvHfNrbHuYbqTaEeOAJ3aoF3v6WGD6WipVWfIRwtoiVO0egUUB0h+IJP1z8z+o1cSAfKQ55TKS8HzWoQtsKYwZP4qra3g0jwh/b87wxZVUkfEoBxk6v0rgKaf4v2qI3EZt2Ssi3c2OTnZvnS/6KNkhELcLTSMs4KxTleoYMRRhO0qsSbGuWLR2FFlP4FgztqwrbGwUn0OJT2Ps7lpdCjqkpznED6A8Xf9ylSd/M8PsbN1GMmry8Dg7yDxHNwx/b3nouobQPFge7lbjvoqZ+cNgc35/c376Q9R47123QUu5svUALTKxrVSF8wiYARdlDiPmhWoHYpgFwNrh9C0elW1NorMoW29qFOvNDpe2bVMLLw+11bcIwqE+RqB7C5y93AXbM1ub5rsdHPe6je5Ai3IMannm1wi25XiroCNh3DGGC88ZGLPTFmalg0BbghVz/zlbJxV87WCvWjitIwhXZbXNWM6vRp+BRtbm9p/TknU2M4o19rAPA9bZ5YG11rDh4RpWYVpx+RO4T4+jj0MTh6YvfusvLBjfdXH943A1VKsKaqY32yx3zfwfyePAO648VsNNg9uPje0zbTpL8sY9krcciVwT6xxENsb5SeW6P50X97HALPvwMQNfQVkpADBHCSJrpRNycc+r/hArlZOd/ya/73Yqh+wYCHBgIIC37aasMRBg9MVuDlat9uCeIw7Acy9PyXYu3Ye7i89hJfGeUtZrS1nvOFLW3GLimnu/t5ayRkEncxFMB5aaXktqShdBrgRDPUjnedLxUbFqJKcVV2N5lICyHEVnBZezuAGmuhvAPrnmFAGelBH0Df88YK8UHRUI+5TA30u+ml9WJV73qtLqrnU8Ac3TTKxmRr/A18L+fyTnGHs6Ss49JacZe3pezXmBy1JH8Z4evMi1p+bscJ9qcBlOc/qm5tx3WWpmGPCx3Keme9N3d3OHGvkP16jtZaxqeO90hypFOspPyZmzyE/X1YsNB4hcbdvGRa9CXfwiVNfM/TgUDQyP0d4zd7Mgf3YcivrGYpfnD0tFBf8GFRsznJGLH3DxbGtBE8OjEx5OxR1n5QnNXKCIL9S0Z+QffG9Qzsi/giLmTR3zKBAeTK8uaU3Gv6nvkdQrRXXQnriWf19KBPjJMP9mLa0Yp7RW4y7R487UP8snovzxa3/jtH+oaf+kCuo/w/b+9qjtjHr1jHtOO4JR/R7zOXiYN6zO2lOvThzrg5JOuefUb/+FWd+ykgD2RQhS7ccDYtnoo3h8uc+P/4VbdNCoPzM8ClQJirMIVH3H6RAbTttm5F0eBgciVx9Oqx39x19w9zr2Vh0Lg+qL69Kagn33Vk0qb6f6OuSRvJ8T29NvFAwcle/7mxDKIMiD7cs+XrJleKR9xX3EpQTKeebzeqmOczgv6WH9V7eK7PVfgOs+/A8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <path d="M 844 120 L 844 199.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
+        <path d="M 844 207.76 L 840 199.76 L 848 199.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 181px; margin-left: 911px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                Executes signed
+                                <br/>
+                                requests to a registry.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="911" y="184" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Executes signed...
+                </text>
+            </switch>
+        </g>
+        <path d="M 424 720 L 424 789.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" stroke-dasharray="6 6" pointer-events="stroke"/>
+        <path d="M 424 797.76 L 420 789.76 L 428 789.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 757px; margin-left: 425px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                Stores and reads data protected by
+                                <br/>
+                                commitments and other private data.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="425" y="760" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Stores and reads data protected by...
+                </text>
+            </switch>
+        </g>
+        <rect x="724" y="0" width="240" height="120" fill="#8c8496" stroke="#736782" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 60px; margin-left: 725px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Account abstraction
+                                    </b>
+                                </font>
+                                <div>
+                                    [Out of scope system]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        <font color="#cccccc">
+                                            Concept of accounts, users and holdings, manages public-private key pairs.
+                                        </font>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="844" y="64" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Account abstraction...
+                </text>
+            </switch>
+        </g>
+        <rect x="274" y="160" width="786" height="560" rx="10" ry="10" fill="none" stroke="#808080" stroke-dasharray="8 4" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-end; justify-content: unsafe flex-start; width: 768px; height: 1px; padding-top: 709px; margin-left: 284px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        <div style="text-align: left">
+                                            Registry
+                                        </div>
+                                    </b>
+                                </font>
+                                <div style="text-align: left">
+                                    [Container]
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="284" y="709" fill="#808080" font-family="Helvetica" font-size="11px">
+                    Registry...
+                </text>
+            </switch>
+        </g>
+        <rect x="724" y="800" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 860px; margin-left: 725px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Verifiable event store
+                                    </b>
+                                </font>
+                                <div>
+                                    [Container: to be determined]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        <font color="#E6E6E6">
+                                            Stores events as public data, and arranges them in a series of merkel trees, each root publishes to the blockchain after a set time or number of events.
+                                        </font>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="844" y="863" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Verifiable event store...
+                </text>
+            </switch>
+        </g>
+        <path d="M 304 815 C 304 806.72 357.73 800 424 800 C 455.83 800 486.35 801.58 508.85 804.39 C 531.36 807.21 544 811.02 544 815 L 544 905 C 544 913.28 490.27 920 424 920 C 357.73 920 304 913.28 304 905 Z" fill="#23a2d9" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 544 815 C 544 823.28 490.27 830 424 830 C 357.73 830 304 823.28 304 815" fill="none" stroke="#0e7dad" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 873px; margin-left: 305px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Secret data store
+                                    </b>
+                                </font>
+                                <div>
+                                    [Container : to be determined]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        <font color="#E6E6E6">
+                                            Stores secret data like commitments and other data that might be categorised as private.
+                                        </font>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="424" y="876" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Secret data store...
+                </text>
+            </switch>
+        </g>
+        <rect x="314" y="210" width="240" height="120" rx="7.2" ry="7.2" fill="#63bef2" stroke="#2086c9" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 270px; margin-left: 315px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Dispatcher
+                                    </b>
+                                </font>
+                                <div>
+                                    [Component: C#]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        Dispaches verify calls to the correct IRequestVerifier implementation.
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="434" y="274" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Dispatcher...
+                </text>
+            </switch>
+        </g>
+        <rect x="534" y="370" width="240" height="120" rx="7.2" ry="7.2" fill="#63bef2" stroke="#2086c9" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 430px; margin-left: 535px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        ModelLoader
+                                    </b>
+                                </font>
+                                <div>
+                                    [Component: e.g. Spring Service]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        Builds a model based on a series of events.
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="654" y="434" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    ModelLoader...
+                </text>
+            </switch>
+        </g>
+        <rect x="724" y="210" width="240" height="120" rx="7.2" ry="7.2" fill="#63bef2" stroke="#2086c9" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 270px; margin-left: 725px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        RequestProcessor
+                                    </b>
+                                </font>
+                                <div>
+                                    [Component: C#]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        Takes requests and ensures sequencial verification and publication of events for same EventStream.
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="844" y="274" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    RequestProcessor...
+                </text>
+            </switch>
+        </g>
+        <path d="M 724 270 L 564.24 270" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 556.24 270 L 564.24 266 L 564.24 274 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 249px; margin-left: 635px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Uses dispatcher to route
+                                <br/>
+                                call to correct verifier.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="635" y="252" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Uses dispatcher to route...
+                </text>
+            </switch>
+        </g>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe flex-start; width: 258px; height: 1px; padding-top: 7px; margin-left: 276px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        <div style="text-align: left">
+                                            [Components] Registry
+                                        </div>
+                                    </b>
+                                </font>
+                                <div style="text-align: left">
+                                    Validates requests and ensures that the events are valid and allowed based on the logic and rules.
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="276" y="19" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px">
+                    [Components] Registry...
+                </text>
+            </switch>
+        </g>
+        <path d="M 684 490 L 684 740 L 784 740 L 784 789.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 784 797.76 L 780 789.76 L 788 789.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 519px; margin-left: 636px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Loads events
+                                <br/>
+                                for a specific
+                                <br/>
+                                eventStreamId.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="636" y="522" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Loads events...
+                </text>
+            </switch>
+        </g>
+        <path d="M 494 330 L 494 400 L 523.76 400" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 531.76 400 L 523.76 404 L 523.76 396 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 363px; margin-left: 395px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Uses ModelLoader to build a
+                                <br/>
+                                model to be used by the verifier.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="395" y="366" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Uses ModelLoader to build a...
+                </text>
+            </switch>
+        </g>
+        <path d="M 964 270 L 990 270 L 990 740 L 904 740 L 904 789.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 904 797.76 L 900 789.76 L 908 789.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 293px; margin-left: 1024px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Publishes
+                                <br/>
+                                verified
+                                <br/>
+                                events.
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1024" y="296" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Publishes...
+                </text>
+            </switch>
+        </g>
+        <rect x="314" y="540" width="240" height="120" rx="7.2" ry="7.2" fill="#63bef2" stroke="#2086c9" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 600px; margin-left: 315px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Projector
+                                    </b>
+                                </font>
+                                <div>
+                                    [Component: C#]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        Has the ability to project a series of events to a IModel
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="434" y="604" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Projector...
+                </text>
+            </switch>
+        </g>
+        <path d="M 534 460 L 494 460 L 494 529.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 494 537.76 L 490 529.76 L 498 529.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 492px; margin-left: 405px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Uses projectors to apply
+                                <br/>
+                                events into a class
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="405" y="495" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Uses projectors to apply...
+                </text>
+            </switch>
+        </g>
+        <rect x="724" y="540" width="240" height="120" rx="7.2" ry="7.2" fill="#63bef2" stroke="#2086c9" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 600px; margin-left: 725px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        EventSerializer
+                                    </b>
+                                </font>
+                                <div>
+                                    [Component: C# with Json serializer.]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        Serializes and Deserializes events.
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="844" y="604" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    EventSerializer...
+                </text>
+            </switch>
+        </g>
+        <path d="M 904 330 L 904 510 L 904 529.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 904 537.76 L 900 529.76 L 908 529.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 351px; margin-left: 871px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Serialize
+                                <br/>
+                                events
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="871" y="354" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Serialize...
+                </text>
+            </switch>
+        </g>
+        <path d="M 774 430 L 844 430 L 844 529.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 844 537.76 L 840 529.76 L 848 529.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 446px; margin-left: 810px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Deserialize
+                                <br/>
+                                events
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="810" y="449" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Deserialize...
+                </text>
+            </switch>
+        </g>
+        <rect x="0" y="370" width="240" height="120" fill="#23a2d9" stroke="#0e7dad" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 238px; height: 1px; padding-top: 430px; margin-left: 1px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                <font style="font-size: 16px">
+                                    <b>
+                                        Electricity
+                                    </b>
+                                </font>
+                                <div>
+                                    [Container: C# Hard coded rules]
+                                </div>
+                                <br/>
+                                <div>
+                                    <font style="font-size: 11px">
+                                        <font color="#E6E6E6">
+                                            Implements the specific ruleset for the electricity domain.
+                                        </font>
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="120" y="433" fill="#ffffff" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    Electricity...
+                </text>
+            </switch>
+        </g>
+        <path d="M 314 270 L 120 270 L 120 359.76" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 120 367.76 L 116 359.76 L 124 359.76 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 291px; margin-left: 186px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Instanciate validators
+                                <br/>
+                                and executions them
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="186" y="294" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Instanciate validators...
+                </text>
+            </switch>
+        </g>
+        <path d="M 314 600 L 120 600 L 120 500.24" fill="none" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <path d="M 120 492.24 L 124 500.24 L 116 500.24 Z" fill="#808080" stroke="#808080" stroke-width="2" stroke-miterlimit="10" pointer-events="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 578px; margin-left: 181px;">
+                        <div data-drawio-colors="color: #808080; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(128, 128, 128); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                Instanciates models
+                                <br/>
+                                and applies events
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="181" y="581" fill="#808080" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Instanciates models...
+                </text>
+            </switch>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/ConcordiumIntegrationTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/ConcordiumIntegrationTests.cs
@@ -1,0 +1,74 @@
+using Microsoft.Extensions.Options;
+using Moq;
+using ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+using Xunit;
+
+namespace ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests;
+
+public class ConcordiumIntegrationTests
+{
+    const string nodeAddress = "http://testnet-node:10001";
+    const string nodeToken = "rpcadmin";
+    const int fiveSeconds = 5000;
+
+    [Fact]
+    public async Task GetRandomKnownTransaction_Success()
+    {
+        var randomKnownTransactionHash = "f8931b7da1f1464453d78e8ab606dee44b3bca00c91170e2fcbcba552da485f4";
+        var knownBlockId = "06a531f87594658eee1aeb369b3e755e5b5bb6a34501aa5d24e2adfa025e7343";
+
+        var connector = GetConcordiumConnector();
+
+        var block = await connector.GetBlock(new TransactionReference(randomKnownTransactionHash));
+
+        Assert.NotNull(block);
+        Assert.True(block?.Final);
+        Assert.Equal(knownBlockId, block?.BlockId);
+    }
+
+    [Fact]
+    public async Task PublishHelloWorld_Success()
+    {
+        var connector = GetConcordiumConnector();
+
+        var transactionRef = await connector.PublishBytes(System.Text.Encoding.UTF8.GetBytes("Hello world"));
+
+        Assert.NotNull(transactionRef);
+    }
+
+    [Fact]
+    public async Task PublishAndWaitForTransaction_Success()
+    {
+        var connector = GetConcordiumConnector();
+
+        var transactionRef = await connector.PublishBytes(System.Text.Encoding.UTF8.GetBytes("Hello world"));
+
+        Block? block;
+        var i = 0;
+        do
+        {
+            await Task.Delay(fiveSeconds);
+            block = await connector.GetBlock(transactionRef);
+        }
+        while (block is null && i++ < 10);
+
+        Assert.NotNull(block);
+        Assert.True(block?.Final);
+    }
+
+    private ConcordiumConnector GetConcordiumConnector()
+    {
+        var accountAddress = GetEnvironmentVariable("AccountAddress");
+        var accountKey = GetEnvironmentVariable("AccountKey");
+
+        var optionsMock = new Mock<IOptions<ConcordiumOptions>>();
+        optionsMock.Setup(obj => obj.Value).Returns(new ConcordiumOptions(nodeAddress, nodeToken, accountAddress, accountKey));
+
+        return new ConcordiumConnector(optionsMock.Object);
+    }
+
+    private string GetEnvironmentVariable(string name)
+    {
+        return Environment.GetEnvironmentVariable(name) ?? throw new ArgumentException($"Environment variable ”{name}” does not exist!");
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests.csproj
+++ b/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+	  <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectOrigin.VerifiableEventStore\ProjectOrigin.VerifiableEventStore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/README.md
+++ b/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/README.md
@@ -1,0 +1,75 @@
+# Integration test with Concordium
+
+To be able to run the integration test with Concordium,
+a Concordium node and github self-hosted runner is required.
+
+This can be achieved using the included [docker-compose](../ProjectOrigin.VerifiableEventStore.Tests/docker-compose.yaml).
+One forking the repo, one must get a token from GitHub to be able to join runners.
+
+## Running a node
+1. Make a .env file containing the following environment variables:
+
+```sh
+GITHUB_RUNNER_TOKEN=#YOUR_GITHUB_RUNNER_TOKEN
+CONCORDIUM_HOST_DIRECTORY=/var/concordium/data
+```
+
+2. Next get the docker-compose file and run it. ***Note: it takes quite a while before the node has processed all blocks and are ready. (hours)***
+
+    The long time for the node to be ready is why this is done in this matter instead of in a GitHub workflow, since it wouldn't be feasible.
+
+```sh
+#wget -qO- https://raw.githubusercontent.com/project-origin/registry/main/src/ProjectOrigin.VerifiableEventStore.Tests/docker-compose.yaml | docker-compose -f - up -d
+wget -qO- https://raw.githubusercontent.com/project-origin/registry/eventstore/integration-tests/src/ProjectOrigin.VerifiableEventStore.Tests/docker-compose.yaml | docker-compose -f - up -d --build
+```
+
+3. One can use the following command, to get what block it has gotten to from the node.
+
+```sh
+concordium-client --grpc-port 10001 block show
+```
+
+## Creating an identity
+
+1. Create an Identity and Account with Concordium.
+
+    To create these, follow the [Concordium documentation](https://developer.concordium.software/en/mainnet/net/guides/company-identities.html)
+for the testnet. More info can be found [here](https://github.com/Concordium/concordium-base/blob/main/rust-bins/docs/user-cli.md#generate-a-version-0-request-for-the-version-0-identity-object
+).
+
+```sh
+user_cli generate-request --cryptographic-parameters cryptographic-parameters-testnet.json \
+                          --ars ars-testnet.json \
+                          --ip-info ip-info-testnet.json \
+                          --initial-keys-out initial-keys.json \ # keys of the initial account together with its address.
+                          --id-use-data-out id-use-data.json \ # data that enables use of the identity object
+                          --request-out request.json # request to send to the identity provider
+```
+
+2. Wait for Concordium to respond with the **id-object.json**.
+
+3. Create the account as described in the [Concordium doc](https://github.com/Concordium/concordium-base/blob/main/rust-bins/docs/user-cli.md#create-accounts-from-a-version-0-identity-object)
+
+```sh
+user_cli create-credential --id-use-data id-use-data.json \
+                           --id-object id-object.json \
+                           --keys-out account-keys.json \
+                           --credential-out credential.json
+```
+
+4. Upload credential to concordium
+
+```sh
+concordium-client transaction deploy-credential credential.json
+```
+
+## Configure GitHub environment
+
+1. Create a Environment on GitHub named testnet
+
+2. Add 2 secrets:
+
+    1. AccountAddress - should contain the address to pay for the tests.
+    2. AccountKey - should contain the hex key for the account.
+
+3. Run tests

--- a/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/docker-compose.yaml
+++ b/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/docker-compose.yaml
@@ -1,0 +1,99 @@
+# This is an example configuration for running the testnet node
+version: '3'
+services:
+  github-runner:
+    build:
+      context: .
+      dockerfile: github-runner.dockerfile
+      args:
+        TOKEN: ${GITHUB_RUNNER_TOKEN}
+        REPOSITORY: https://github.com/project-origin/registry
+        NAME: concordium-workflow-runner
+        LABELS: concordium-test
+    restart: always
+    container_name: github-runner
+  testnet-node:
+    container_name: testnet-node
+    image: concordium/testnet-node:4.2.3-0
+    pull_policy: always
+    environment:
+      # Environment specific configuration
+      # The url where IPs of the bootstrap nodes can be found.
+      - CONCORDIUM_NODE_CONNECTION_BOOTSTRAP_NODES=bootstrap.testnet.concordium.com:8888
+      # Where the genesis is located
+      - CONCORDIUM_NODE_CONSENSUS_GENESIS_DATA_FILE=/testnet-genesis.dat
+      # General node configuration Data and config directories (it's OK if they
+      # are the same). This should match the volume mount below. If the location
+      # of the mount inside the container is changed, then these should be
+      # changed accordingly as well.
+      - CONCORDIUM_NODE_DATA_DIR=/mnt/data
+      - CONCORDIUM_NODE_CONFIG_DIR=/mnt/data
+      # The port on which the node will listen for incoming connections. This is a
+      # port inside the container. It is mapped to an external port by the port
+      # mapping in the `ports` section below. If the internal and external ports
+      # are going to be different then you should also set
+      # `CONCORDIUM_NODE_EXTERNAL_PORT` variable to what the external port value is.
+      - CONCORDIUM_NODE_LISTEN_PORT=8889
+      # Desired number of nodes to be connected to.
+      - CONCORDIUM_NODE_CONNECTION_DESIRED_NODES=5
+      # Maximum number of __nodes__ the node will be connected to.
+      - CONCORDIUM_NODE_CONNECTION_MAX_ALLOWED_NODES=10
+      # Address of the GRPC server
+      - CONCORDIUM_NODE_RPC_SERVER_ADDR=0.0.0.0
+      # And its port
+      - CONCORDIUM_NODE_RPC_SERVER_PORT=10001
+      # Maximum number of __connections__ the node can have. This can temporarily be more than
+      # the number of peers when incoming connections are processed. This limit
+      # ensures that there cannot be too many of those.
+      - CONCORDIUM_NODE_CONNECTION_HARD_CONNECTION_LIMIT=20
+      # Number of threads to use to process network events. This should be
+      # adjusted based on the resources the node has (in combination with
+      # `CONCORDIUM_NODE_BAKER_HASKELL_RTS_FLAGS`) below.
+      - CONCORDIUM_NODE_CONNECTION_THREAD_POOL_SIZE=2
+      # The bootstrapping interval in seconds. This makes the node contact the
+      # specified bootstrappers at a given interval to discover new peers.
+      - CONCORDIUM_NODE_CONNECTION_BOOTSTRAPPING_INTERVAL=1800
+      # Haskell RTS flags to pass to consensus. `-N2` means to use two threads
+      # for consensus operations. `-I0` disables the idle garbage collector
+      # which reduces CPU load for non-baking nodes.
+      - CONCORDIUM_NODE_BAKER_HASKELL_RTS_FLAGS=-N2,-I0
+    entrypoint: ["/concordium-node"]
+    # Exposed ports. The ports the node listens on inside the container (defined
+    # by `CONCORDIUM_NODE_LISTEN_PORT` and `CONCORDIUM_NODE_RPC_SERVER_PORT`)
+    # should match what is defined here. When running multiple nodes the
+    # external ports should be changed so as not to conflict.
+    # In the mapping below, the first port is the `host` port, and the second
+    # port is the `container` port. When the `container` port is changed the
+    # relevant environment variable listed above must be changed as well. For
+    # example, changing `10001:10001` to `10001:13000` would mean that
+    # `CONCORDIUM_NODE_RPC_SERVER_PORT` should be set to `13000`. Otherwise
+    # the node's gRPC interface will not be available from the host.
+    ports:
+    - "8889:8889"
+    - "10001:10001"
+    volumes:
+    # The node's database should be stored in a persistent volume so that it
+    # survives container restart. In this case we map the **host** directory
+    # /var/lib/concordium-testnet to be used as the node's database directory.
+    - ${CONCORDIUM_HOST_DIRECTORY}:/mnt/data
+  # The collector reports the state of the node to the network dashboard. A node
+  # can run without reporting to the network dashboard. Remove this section if
+  # that is desired.
+  testnet-node-collector:
+    container_name: testnet-node-collector
+    image: concordium/testnet-node:4.2.3-0
+    pull_policy: always
+    environment:
+      # Settings that should be customized by the user.
+      - CONCORDIUM_NODE_COLLECTOR_NODE_NAME=project-origin-test
+      # Environment specific settings.
+      - CONCORDIUM_NODE_COLLECTOR_URL=https://dashboard.testnet.concordium.com/nodes/post
+      # Collection settings.
+      # How often to collect the statistics from the node.
+      - CONCORDIUM_NODE_COLLECTOR_COLLECT_INTERVAL=5000
+      # The URL where the node can be reached. Note that this will use the
+      # docker created network which maps `testnet-node` to the internal IP of
+      # the `testnet-node`. If the name of the node service is changed from
+      # `testnet-node` then the name here must also be changed.
+      - CONCORDIUM_NODE_COLLECTOR_GRPC_HOST=http://testnet-node:10001
+    entrypoint: ["/node-collector"]

--- a/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/github-runner.dockerfile
+++ b/src/ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests/github-runner.dockerfile
@@ -1,0 +1,41 @@
+# Base ubuntu image
+FROM ubuntu:20.04
+
+# Github runner version https://github.com/actions/runner/releases
+ARG VERSION="2.298.2"
+ARG TOKEN
+ARG REPOSITORY="https://github.com/project-origin/registry"
+ARG NAME="concordium-workflow-runner"
+ARG LABELS="concordium-testnet"
+
+# Set env variables
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Update and install packages
+RUN apt-get update -y &&\
+    apt-get upgrade -y &&\
+    apt-get install -y --no-install-recommends curl ca-certificates unzip sudo git make
+
+# Configure user and ownership
+RUN useradd -m runner &&\
+    usermod -aG sudo runner &&\
+    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+# Set workdir
+WORKDIR /home/runner/actions-runner
+
+# Mkdir for runner, download, unzip
+RUN curl -o runner.tar.gz -L https://github.com/actions/runner/releases/download/v${VERSION}/actions-runner-linux-x64-${VERSION}.tar.gz &&\
+    tar xzf runner.tar.gz &&\
+    rm runner.tar.gz &&\
+    ./bin/installdependencies.sh &&\
+    chown -R runner /home/runner &&\
+    chown -R runner /usr/share
+
+# Set user as "runner"
+USER runner
+
+# Configure runner
+RUN ./config.sh --unattended --url ${REPOSITORY} --token ${TOKEN} --replace --name ${NAME} --labels ${LABELS}
+
+ENTRYPOINT ./run.sh

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/ConcordiumTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/ConcordiumTests.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+using NSec.Cryptography;
+using ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+
+namespace ProjectOrigin.VerifiableEventStore.Tests;
+
+public class ConcordiumTests
+{
+    const string nodeAddress = "http://testnet-node:10001";
+    const string nodeToken = "rpcadmin";
+    const string fakeAccount = "MmU1ZTdlYjYzOWJmODc0MjNiYWM1Nzk2Y2ViMWY3MGU4MDU5Mz";
+    const string fakePrivateKey = "2e5e7eb639bf87423bac5796ceb1f70e805e938803e36154e361892214974926";
+
+    [Fact]
+    public void ConcodiumConnector_Instanciate_Success()
+    {
+        var optionsMock = new Mock<IOptions<ConcordiumOptions>>();
+        optionsMock.Setup(obj => obj.Value).Returns(new ConcordiumOptions(nodeAddress, nodeToken, fakeAccount, fakePrivateKey));
+        var connector = new ConcordiumConnector(optionsMock.Object);
+
+        Assert.NotNull(connector);
+    }
+
+    [Fact]
+    public void ConcodiumConnector_InvalidKey_Fails()
+    {
+        var optionsMock = new Mock<IOptions<ConcordiumOptions>>();
+        optionsMock.Setup(obj => obj.Value).Returns(new ConcordiumOptions(nodeAddress, nodeToken, fakeAccount, "invalidkey"));
+
+        Assert.ThrowsAny<ArgumentException>(() => new ConcordiumConnector(optionsMock.Object));
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/MemoryBatcherTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/MemoryBatcherTests.cs
@@ -1,0 +1,48 @@
+using System.Security.Cryptography;
+using Microsoft.Extensions.Options;
+using ProjectOrigin.VerifiableEventStore.Models;
+using ProjectOrigin.VerifiableEventStore.Services.Batcher;
+using ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+using ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+namespace ProjectOrigin.VerifiableEventStore.Tests;
+
+public class MemoryBatcherTests
+{
+    [Fact]
+    public async Task MemoryBatcher_WhenBatchIsFull_BatchIsStoredAndPublished()
+    {
+        var blockId = new Fixture().Create<string>();
+        var transactionId = new Fixture().Create<string>();
+        var event1 = new Fixture().Create<Event>();
+        var event2 = new Fixture().Create<Event>();
+
+        var rootHash = CalculateRoot(event1.Content, event2.Content);
+
+        var optionsMock = new Mock<IOptions<BatcherOptions>>();
+        optionsMock.Setup(obj => obj.Value).Returns(new BatcherOptions { BatchSizeExponent = 1 });
+
+        var eventStoreMock = new Mock<IEventStore>();
+
+        var blockchainMock = new Mock<IBlockchainConnector>();
+        blockchainMock.Setup(obj => obj.PublishBytes(It.Is<byte[]>(b => b[0] == rootHash[0]))).Returns(Task.FromResult(new TransactionReference(transactionId)));
+        blockchainMock.Setup(obj => obj.GetBlock(It.IsAny<TransactionReference>())).Returns(Task.FromResult<Block?>(new Block(blockId, true)));
+
+
+        var batcher = new MemoryBatcher(blockchainMock.Object, eventStoreMock.Object, optionsMock.Object);
+
+        await batcher.PublishEvent(event1);
+        await batcher.PublishEvent(event2);
+
+        eventStoreMock.Verify(obj => obj.StoreBatch(It.Is<Batch>(b => b.BlockId == blockId && b.TransactionId == transactionId && b.Events.Count == 2)), Times.Once);
+        blockchainMock.Verify(obj => obj.PublishBytes(It.Is<byte[]>(b => b[0] == rootHash[0])), Times.Once);
+    }
+
+    private byte[] CalculateRoot(byte[] left, byte[] right)
+    {
+        var shaLeft = SHA256.HashData(left);
+        var shaRight = SHA256.HashData(right);
+
+        return SHA256.HashData(shaLeft.Concat(shaRight).ToArray());
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/MemoryEventStoreTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/MemoryEventStoreTests.cs
@@ -1,0 +1,33 @@
+using ProjectOrigin.VerifiableEventStore.Models;
+using ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+namespace ProjectOrigin.VerifiableEventStore.Tests;
+
+public class MemoryEventStoreTests
+{
+    [Fact]
+    public async Task MemoryEventStore_StoreEvents_ReturnsBatch()
+    {
+        var batch1 = new Fixture().Create<Batch>();
+        var batch2 = new Fixture().Create<Batch>();
+
+        var memoryEventStore = new MemoryEventStore();
+
+        await memoryEventStore.StoreBatch(batch1);
+        await memoryEventStore.StoreBatch(batch2);
+
+        var batchResult = await memoryEventStore.GetBatch(batch1.Events.First().Id);
+
+        Assert.Equal(batch1, batchResult);
+    }
+
+    [Fact]
+    public async Task MemoryEventStore_GetBatchNotFound_ReturnNull()
+    {
+        var memoryEventStore = new MemoryEventStore();
+        var eventId = new Fixture().Create<EventId>();
+        var batchResult = await memoryEventStore.GetBatch(eventId);
+
+        Assert.Null(batchResult);
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/MerkleTreeTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/MerkleTreeTests.cs
@@ -1,0 +1,71 @@
+using System.Security.Cryptography;
+using ProjectOrigin.VerifiableEventStore.Extensions;
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.VerifiableEventStore.Tests;
+
+public class MerkleTreeTests
+{
+    [Theory]
+    [InlineData(2, 1, 1)]
+    [InlineData(4, 1, 2)]
+    [InlineData(8, 5, 3)]
+    [InlineData(16, 5, 4)]
+    public void GetRequiredHashes_ValidateNumberOfHashesReturned(int numberOfEvents, int leafIndex, int numberOfHashes)
+    {
+        var events = new Fixture().CreateMany<Event>(numberOfEvents);
+        var hashes = events.GetRequiredHashes(x => x.Content, leafIndex);
+
+        Assert.Equal(numberOfHashes, hashes.Count());
+    }
+
+    [Theory]
+    [InlineData(2, 1)]
+    [InlineData(2, 0)]
+    [InlineData(4, 0)]
+    [InlineData(4, 1)]
+    [InlineData(4, 2)]
+    [InlineData(4, 3)]
+    [InlineData(8, 5)]
+    [InlineData(16, 9)]
+    [InlineData(32, 15)]
+    public void GetRequiredHashes_ValidateHashesCorrect(int numberOfEvents, int leafIndex)
+    {
+        var events = new Fixture().CreateMany<Event>(numberOfEvents);
+        var hashes = events.GetRequiredHashes(x => x.Content, leafIndex);
+
+        var calculatedRoot = HashRootFromMerkleProof(hashes, leafIndex, events.Skip(leafIndex).First().Content);
+
+        var rootHash = events.CalculateMerkleRoot(e => e.Content);
+
+        Assert.Equal(rootHash, calculatedRoot);
+    }
+
+    private byte[] HashRootFromMerkleProof(IEnumerable<byte[]> hashes, int leafIndex, byte[] content)
+    {
+        if (hashes.Count() == 1)
+        {
+            if (leafIndex == 0)
+            {
+                return SHA256Array.HashData(SHA256.HashData(content), hashes.Single());
+            }
+            else
+            {
+                return SHA256Array.HashData(hashes.Single(), SHA256.HashData(content));
+            }
+        }
+        else
+        {
+            var numberOfEvents = (int)Math.Pow(2, hashes.Count());
+            if (leafIndex >= numberOfEvents / 2)
+            {
+                return SHA256Array.HashData(hashes.First(), HashRootFromMerkleProof(hashes.Skip(1), leafIndex - numberOfEvents / 2, content));
+            }
+            else
+            {
+                return SHA256Array.HashData(HashRootFromMerkleProof(hashes.Take(hashes.Count() - 1), leafIndex, content), hashes.Last());
+
+            }
+        }
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/ProjectOrigin.VerifiableEventStore.Tests.csproj
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/ProjectOrigin.VerifiableEventStore.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="AutoFixture" Version="4.17.0" />
+	  <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ProjectOrigin.VerifiableEventStore\ProjectOrigin.VerifiableEventStore.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/Usings.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/Usings.cs
@@ -1,0 +1,3 @@
+global using AutoFixture;
+global using Moq;
+global using Xunit;

--- a/src/ProjectOrigin.VerifiableEventStore/Extensions/IEnumerableMerkleExtension.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Extensions/IEnumerableMerkleExtension.cs
@@ -1,0 +1,74 @@
+using System.Security.Cryptography;
+
+namespace ProjectOrigin.VerifiableEventStore.Extensions;
+
+public static class IEnumerableMerkleExtension
+{
+    public static byte[] CalculateMerkleRoot<T>(this IEnumerable<T> events, Func<T, byte[]> selector)
+    {
+        if (!IsPowerOfTwo(events.Count()))
+        {
+            throw new NotSupportedException("CalculateMerkleRoot currently only supported on exponents of 2");
+        }
+
+        return RecursiveShaNodes(events.Select(selector));
+    }
+
+    public static IEnumerable<byte[]> GetRequiredHashes<T>(this IEnumerable<T> events, Func<T, byte[]> selector, int leafIndex)
+    {
+        return RecursiveGetRequiredHashes(events.Select(selector), leafIndex);
+    }
+
+    private static IEnumerable<byte[]> RecursiveGetRequiredHashes(IEnumerable<byte[]> events, int leafIndex)
+    {
+        if (events.Count() == 2)
+        {
+            yield return SHA256.HashData(events.Skip(1 - leafIndex).First());
+        }
+        else
+        {
+            var i = events.Count() / 2;
+            if (leafIndex >= i)
+            {
+                yield return RecursiveShaNodes(events.Take(i));
+                foreach (var x in RecursiveGetRequiredHashes(events.Skip(i), leafIndex - i))
+                {
+                    yield return x;
+                }
+            }
+            else
+            {
+                foreach (var x in RecursiveGetRequiredHashes(events.Take(i), leafIndex))
+                {
+                    yield return x;
+                }
+                yield return RecursiveShaNodes(events.Skip(i));
+            }
+        }
+    }
+
+    private static byte[] RecursiveShaNodes(IEnumerable<byte[]> nodes)
+    {
+        if (nodes.Count() == 1)
+        {
+            return SHA256.HashData(nodes.Single());
+        }
+
+        var newList = new List<byte[]>();
+
+        for (var i = 0; i < nodes.Count(); i = i + 2)
+        {
+            var left = SHA256.HashData(nodes.Skip(i).First());
+            var right = SHA256.HashData(nodes.Skip(i + 1).First());
+
+            newList.Add(left.Concat(right).ToArray());
+        }
+
+        return RecursiveShaNodes(newList);
+    }
+
+    private static bool IsPowerOfTwo(int x)
+    {
+        return (x & (x - 1)) == 0;
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Extensions/SHA256Extensions.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Extensions/SHA256Extensions.cs
@@ -1,0 +1,12 @@
+
+using System.Security.Cryptography;
+
+namespace ProjectOrigin.VerifiableEventStore.Extensions;
+
+public class SHA256Array
+{
+    public static byte[] HashData(params byte[][] data)
+    {
+        return SHA256.HashData(data.SelectMany(x => x).ToArray());
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Models/Batch.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Models/Batch.cs
@@ -1,0 +1,3 @@
+namespace ProjectOrigin.VerifiableEventStore.Models;
+
+public record Batch(string BlockId, string TransactionId, List<Event> Events);

--- a/src/ProjectOrigin.VerifiableEventStore/Models/Event.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Models/Event.cs
@@ -1,0 +1,3 @@
+namespace ProjectOrigin.VerifiableEventStore.Models;
+
+public record Event(EventId Id, byte[] Content);

--- a/src/ProjectOrigin.VerifiableEventStore/Models/EventId.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Models/EventId.cs
@@ -1,0 +1,3 @@
+namespace ProjectOrigin.VerifiableEventStore.Models;
+
+public record EventId(Guid EventStreamId, int Index);

--- a/src/ProjectOrigin.VerifiableEventStore/Models/EventId.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Models/EventId.cs
@@ -1,3 +1,6 @@
 namespace ProjectOrigin.VerifiableEventStore.Models;
 
-public record EventId(Guid EventStreamId, int Index);
+public record EventId(Guid EventStreamId, int Index)
+{
+    public override string ToString() => $"{EventStreamId}-{Index}";
+}

--- a/src/ProjectOrigin.VerifiableEventStore/ProjectOrigin.VerifiableEventStore.csproj
+++ b/src/ProjectOrigin.VerifiableEventStore/ProjectOrigin.VerifiableEventStore.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
+    <PackageReference Include="ConcordiumNetSdk" Version="1.0.1" />
+    <PackageReference Include="NSec.Cryptography" Version="22.4.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/ProjectOrigin.VerifiableEventStore/Services/Batcher/BatcherOptions.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/Batcher/BatcherOptions.cs
@@ -1,0 +1,6 @@
+namespace ProjectOrigin.VerifiableEventStore.Services.Batcher;
+
+public record BatcherOptions
+{
+    public long BatchSizeExponent { get; init; }
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/Batcher/IBatcher.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/Batcher/IBatcher.cs
@@ -1,0 +1,8 @@
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.Batcher;
+
+public interface IBatcher
+{
+    Task PublishEvent(Event e);
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/Batcher/MemoryBatcher.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/Batcher/MemoryBatcher.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Options;
+using ProjectOrigin.VerifiableEventStore.Extensions;
+using ProjectOrigin.VerifiableEventStore.Models;
+using ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+using ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.Batcher;
+
+public class MemoryBatcher : IBatcher
+{
+    private IBlockchainConnector blockchainConnector;
+    private IEventStore eventStore;
+    private IOptions<BatcherOptions> options;
+    private List<Event> events = new List<Event>();
+    private long batchSize;
+    private const int blockRetryWaitMilliseconds = 1000;
+
+    public MemoryBatcher(IBlockchainConnector blockchainConnector, IEventStore eventStore, IOptions<BatcherOptions> options)
+    {
+        this.blockchainConnector = blockchainConnector;
+        this.eventStore = eventStore;
+        this.options = options;
+
+        batchSize = (long)Math.Pow(2, options.Value.BatchSizeExponent);
+    }
+
+    public async Task PublishEvent(Event e)
+    {
+        events.Add(e);
+
+        if (events.Count >= batchSize)
+        {
+            var batchEvents = events;
+            events = new List<Event>();
+
+            var batch = await PublishBatch(batchEvents);
+            await eventStore.StoreBatch(batch);
+        }
+    }
+
+    private async Task<Batch> PublishBatch(List<Event> batchEvents)
+    {
+        var root = batchEvents.CalculateMerkleRoot(x => x.Content);
+
+        var transaction = await blockchainConnector.PublishBytes(root);
+
+        var block = await blockchainConnector.GetBlock(transaction);
+        while (block == null || !block.Final)
+        {
+            await Task.Delay(blockRetryWaitMilliseconds);
+            block = await blockchainConnector.GetBlock(transaction);
+        }
+
+        var batch = new Batch(block.BlockId, transaction.TransactionHash, batchEvents);
+        return batch;
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/Block.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/Block.cs
@@ -1,0 +1,3 @@
+namespace ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+
+public record Block(string BlockId, bool Final);

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/ConcordiumConnector.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/ConcordiumConnector.cs
@@ -1,0 +1,60 @@
+using ConcordiumNetSdk;
+using ConcordiumNetSdk.SignKey;
+using ConcordiumNetSdk.Transactions;
+using ConcordiumNetSdk.Types;
+using Microsoft.Extensions.Options;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+
+public class ConcordiumConnector : IBlockchainConnector, IDisposable
+{
+    private IOptions<ConcordiumOptions> options;
+    private ConcordiumNodeClient concordiumNodeClient;
+    private TransactionSigner transactionSigner;
+
+    public ConcordiumConnector(IOptions<ConcordiumOptions> options)
+    {
+        this.options = options;
+        concordiumNodeClient = new ConcordiumNodeClient(
+            new Connection
+            {
+                Address = options.Value.Address,
+                AuthenticationToken = options.Value.AuthenticationToken
+            });
+
+        var ed25519TransactionSigner = Ed25519SignKey.From(options.Value.AccountKey);
+        transactionSigner = new TransactionSigner();
+        transactionSigner.AddSignerEntry(ConcordiumNetSdk.Types.Index.Create(0), ConcordiumNetSdk.Types.Index.Create(0), ed25519TransactionSigner);
+
+    }
+
+
+    public void Dispose() => concordiumNodeClient.Dispose();
+
+    public async Task<Block?> GetBlock(TransactionReference transactionReference)
+    {
+        var transactionHash = TransactionHash.From(transactionReference.TransactionHash);
+
+        var transactionStatus = await concordiumNodeClient.GetTransactionStatusAsync(transactionHash);
+
+        if (transactionStatus != null
+            && transactionStatus.Outcomes != null
+            && transactionStatus.Status == TransactionStatusType.Finalized)
+        {
+            return new Block(transactionStatus.Outcomes.Single().Key, transactionStatus.Status == TransactionStatusType.Finalized);
+        }
+
+        return null;
+    }
+
+    public async Task<TransactionReference> PublishBytes(byte[] bytes)
+    {
+        var accountTransactionService = new AccountTransactionService(concordiumNodeClient);
+
+        var address = AccountAddress.From(options.Value.AccountAddress);
+        var payload = RegisterDataPayload.Create(bytes);
+        var transactionHash = await accountTransactionService.SendAccountTransactionAsync(address, payload, transactionSigner);
+
+        return new TransactionReference(transactionHash.AsString);
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/ConcordiumOptions.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/ConcordiumOptions.cs
@@ -1,0 +1,1 @@
+public record ConcordiumOptions(string Address, string AuthenticationToken, string AccountAddress, string AccountKey);

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/IBlockchainConnector.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/IBlockchainConnector.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+
+public interface IBlockchainConnector
+{
+    Task<TransactionReference> PublishBytes(byte[] bytes);
+
+    Task<Block?> GetBlock(TransactionReference transactionId);
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/RegisterDataPayload.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/RegisterDataPayload.cs
@@ -1,0 +1,47 @@
+using System.Buffers.Binary;
+using ConcordiumNetSdk.Types;
+
+namespace ConcordiumNetSdk.Transactions;
+
+/// <summary>
+/// Represents a contents of the register data transaction.
+/// </summary>
+public class RegisterDataPayload : IAccountTransactionPayload
+{
+    private RegisterDataPayload(byte[] data)
+    {
+        Data = data;
+    }
+
+    /// <summary>
+    /// The data to register.
+    /// </summary>
+    public byte[] Data { get; }
+
+    /// <summary>
+    /// Creates an instance of register data payload.
+    /// </summary>
+    /// <param name="data">the to register on the ledger.</param>
+    public static RegisterDataPayload Create(byte[] data)
+    {
+        if (data.Length > short.MaxValue) throw new InvalidDataException($"Data in RegisterDataPayload is to long, max length is {short.MaxValue}");
+
+        return new RegisterDataPayload(data);
+    }
+
+    public byte[] SerializeToBytes()
+    {
+        var length = Data.Length;
+
+        var bytes = new byte[3 + length];
+        Span<byte> buffer = bytes;
+
+        buffer[0] = (byte)AccountTransactionType.RegisterData;
+        BinaryPrimitives.WriteUInt16BigEndian(buffer.Slice(1, 2), (ushort)length);
+        Data.CopyTo(buffer.Slice(3));
+
+        return bytes;
+    }
+
+    public ulong GetBaseEnergyCost() => 300;
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/TransactionReference.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockchainConnector/TransactionReference.cs
@@ -1,0 +1,3 @@
+namespace ProjectOrigin.VerifiableEventStore.Services.BlockchainConnector;
+
+public record TransactionReference(string TransactionHash);

--- a/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/EventProverService.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/EventProverService.cs
@@ -1,0 +1,30 @@
+using ProjectOrigin.VerifiableEventStore.Extensions;
+using ProjectOrigin.VerifiableEventStore.Models;
+using ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.EventProver;
+
+public class EventProverService : IEventProver
+{
+    private IEventStore eventStore;
+
+    public EventProverService(IEventStore eventStore)
+    {
+        this.eventStore = eventStore;
+    }
+
+    public async Task<MerkleProof?> GetMerkleProof(EventId eventId)
+    {
+        var batch = await eventStore.GetBatch(eventId);
+        if (batch is null)
+        {
+            return null;
+        }
+
+        var eventObj = batch.Events.Single(e => e.Id == eventId);
+        var eventIndex = batch.Events.IndexOf(eventObj);
+        var hashes = batch.Events.GetRequiredHashes(e => e.Content, eventIndex);
+
+        return new MerkleProof(eventId, eventObj.Content, batch.BlockId, batch.TransactionId, batch.Events.IndexOf(eventObj), hashes);
+    }
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/IEventProver.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/IEventProver.cs
@@ -1,0 +1,8 @@
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.EventProver;
+
+public interface IEventProver
+{
+    Task<MerkleProof?> GetMerkleProof(EventId eventId);
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/MerkleProof.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/MerkleProof.cs
@@ -1,0 +1,5 @@
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.EventProver;
+
+public record MerkleProof(EventId EventId, byte[] Event, string BlockId, string TransactionId, long leafIndex, IEnumerable<byte[]> Hashes);

--- a/src/ProjectOrigin.VerifiableEventStore/Services/EventStore/IEventStore.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/EventStore/IEventStore.cs
@@ -1,0 +1,10 @@
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+public interface IEventStore
+{
+    Task StoreBatch(Batch batch);
+    Task<Batch?> GetBatch(EventId eventId);
+    Task<IEnumerable<Event>> GetEventsForEventStream(Guid topic);
+}

--- a/src/ProjectOrigin.VerifiableEventStore/Services/EventStore/MemoryEventStore.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/EventStore/MemoryEventStore.cs
@@ -1,0 +1,26 @@
+using ProjectOrigin.VerifiableEventStore.Models;
+
+namespace ProjectOrigin.VerifiableEventStore.Services.EventStore;
+
+public class MemoryEventStore : IEventStore
+{
+    private List<Batch> batches = new List<Batch>();
+
+    public Task StoreBatch(Batch batch)
+    {
+        batches.Add(batch);
+        return Task.CompletedTask;
+    }
+
+    public Task<Batch?> GetBatch(EventId eventId)
+    {
+        var batch = batches.Where(b => b.Events.Select(e => e.Id).Contains(eventId)).SingleOrDefault();
+        return Task.FromResult(batch);
+    }
+
+    public Task<IEnumerable<Event>> GetEventsForEventStream(Guid streamId)
+    {
+        var events = batches.SelectMany(b => b.Events.Where(e => e.Id.EventStreamId == streamId));
+        return Task.FromResult(events);
+    }
+}

--- a/src/Registry.sln
+++ b/src/Registry.sln
@@ -12,6 +12,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.PedersenCommi
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.PedersenCommitment.Tests", "ProjectOrigin.PedersenCommitment.Tests\ProjectOrigin.PedersenCommitment.Tests.csproj", "{FDA069D8-E8FE-465E-A11E-77BC15E4EB2A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.RequestProcessor", "ProjectOrigin.RequestProcessor\ProjectOrigin.RequestProcessor.csproj", "{EC541F55-C0A9-4694-A902-B41026E9AC73}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.RequestProcessor.Tests", "ProjectOrigin.RequestProcessor.Tests\ProjectOrigin.RequestProcessor.Tests.csproj", "{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,5 +45,13 @@ Global
 		{FDA069D8-E8FE-465E-A11E-77BC15E4EB2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDA069D8-E8FE-465E-A11E-77BC15E4EB2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDA069D8-E8FE-465E-A11E-77BC15E4EB2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EC541F55-C0A9-4694-A902-B41026E9AC73}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EC541F55-C0A9-4694-A902-B41026E9AC73}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EC541F55-C0A9-4694-A902-B41026E9AC73}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EC541F55-C0A9-4694-A902-B41026E9AC73}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/Registry.sln
+++ b/src/Registry.sln
@@ -1,8 +1,13 @@
-
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.30114.105
 MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.VerifiableEventStore", "ProjectOrigin.VerifiableEventStore\ProjectOrigin.VerifiableEventStore.csproj", "{08F84068-CF3C-47B2-ADC5-A1BCDF497EE7}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.VerifiableEventStore.Tests", "ProjectOrigin.VerifiableEventStore.Tests\ProjectOrigin.VerifiableEventStore.Tests.csproj", "{5364EBE0-1AD3-4C1C-9D1A-F90583D48DB5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests", "ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests\ProjectOrigin.VerifiableEventStore.ConcordiumIntegrationTests.csproj", "{B5DAEBAB-6196-469E-9A45-A989907D3A3D}"
+EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.PedersenCommitment", "ProjectOrigin.PedersenCommitment\ProjectOrigin.PedersenCommitment.csproj", "{0A0F1082-9AF8-4A64-8494-4C9C87291421}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.PedersenCommitment.Tests", "ProjectOrigin.PedersenCommitment.Tests\ProjectOrigin.PedersenCommitment.Tests.csproj", "{FDA069D8-E8FE-465E-A11E-77BC15E4EB2A}"
@@ -16,6 +21,18 @@ Global
 		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{08F84068-CF3C-47B2-ADC5-A1BCDF497EE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08F84068-CF3C-47B2-ADC5-A1BCDF497EE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08F84068-CF3C-47B2-ADC5-A1BCDF497EE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08F84068-CF3C-47B2-ADC5-A1BCDF497EE7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5364EBE0-1AD3-4C1C-9D1A-F90583D48DB5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5364EBE0-1AD3-4C1C-9D1A-F90583D48DB5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5364EBE0-1AD3-4C1C-9D1A-F90583D48DB5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5364EBE0-1AD3-4C1C-9D1A-F90583D48DB5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B5DAEBAB-6196-469E-9A45-A989907D3A3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B5DAEBAB-6196-469E-9A45-A989907D3A3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B5DAEBAB-6196-469E-9A45-A989907D3A3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B5DAEBAB-6196-469E-9A45-A989907D3A3D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{0A0F1082-9AF8-4A64-8494-4C9C87291421}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0A0F1082-9AF8-4A64-8494-4C9C87291421}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0A0F1082-9AF8-4A64-8494-4C9C87291421}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
This PR includes a first version of a RequestProcessor library.

Features included:
* Enabled PublishRequests to be evaluated using Verifiers.
* When Requests are valid, they are publishes to the EventStore.
* SynchronousInMemoryRequestProcessor implemented.
* Model projection from a series of Events.
* Verifiers must implement interface.
* PublishRequests must extend abstract class. 

Other additions:
* Updated container diagram.
* Added **/coverage.cobertura.xml to .gitignore to ignore test coverage files
* VSCode settings to make the project work better out of the box.
* Make verify now **runs tests and verifies format** a precursor to know checks on github will succeed.