### PR TITLE
Add link to rendered documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,5 @@ Below is a [system context diagram](https://c4model.com/#SystemContextDiagram) s
 ![C4 system diagram](/doc/system_diagram.drawio.svg)
 
 More in depth information can be found in the [architecture description](doc/architecture.md).
+
+There is also more [conceptual, API and architecture documentation rendered as website](https://project-origin.github.io/registry/index.html).


### PR DESCRIPTION
We do have a rendered version of the documentation (if the compilation + deployment process works) that is quite useful and nice to read. I've added a link to the website to the README.

Please feel free to change the link if it changes. If this is fine, just merge it.