### PR TITLE
added the TODO to Issue action to track future TODOs as issues

### DIFF
--- a/.github/workflows/repo-housekeeping.yml
+++ b/.github/workflows/repo-housekeeping.yml
@@ -1,0 +1,11 @@
+name: "Run TODO to Issue"
+on: ["push"]
+jobs:
+    build:
+        runs-on: "ubuntu-latest"
+        steps:
+            - uses: "actions/checkout@v3"
+            - name: "TODO to Issue"
+              uses: "alstr/todo-to-issue-action@v4"
+              with:
+                  AUTO_ASSIGN: true

--- a/.github/workflows/repo-housekeeping.yml
+++ b/.github/workflows/repo-housekeeping.yml
@@ -1,5 +1,5 @@
 name: "Run TODO to Issue"
-on: ["pull_request"]
+on: ["pull_request"] # TODO: Change to "push" if you want to run on every push - this is a test of the action so we're running on PRs only
 jobs:
     build:
         runs-on: "ubuntu-latest"

--- a/.github/workflows/repo-housekeeping.yml
+++ b/.github/workflows/repo-housekeeping.yml
@@ -1,5 +1,5 @@
 name: "Run TODO to Issue"
-on: ["pull_request"] # TODO: Change to "push" if you want to run on every push - this is a test of the action so we're running on PRs only
+on: ["pull_request"]
 jobs:
     build:
         runs-on: "ubuntu-latest"

--- a/.github/workflows/repo-housekeeping.yml
+++ b/.github/workflows/repo-housekeeping.yml
@@ -1,5 +1,5 @@
 name: "Run TODO to Issue"
-on: ["push"]
+on: ["pull_request"]
 jobs:
     build:
         runs-on: "ubuntu-latest"


### PR DESCRIPTION
After following the [TODO to Issue docs](https://github.com/marketplace/actions/todo-to-issue) I have made an additional repo-housekeeping.yml file for these types of actions as I consider housekeeping.

This is an experimental feature to see if the action works - if we in the future deem it not valuable it can be removed.

I have changed the **event trigger** trigger from push to pull_request because I believe that the push event would create too many issues if TODOs are used extensively while working on a branch. This choice is purely based on above mentioned assumption.