### PR TITLE
Improve proof oracle

### DIFF
--- a/src/ProjectOrigin.PedersenCommitment.Tests/SumProofTests.cs
+++ b/src/ProjectOrigin.PedersenCommitment.Tests/SumProofTests.cs
@@ -130,7 +130,7 @@ public class SumProofTests
     }
 
     [Fact]
-    public void Serde()
+    public void SerialzeDeserialize()
     {
         var label = Encoding.UTF8.GetBytes("test");
         var pc_gens = Generator.Default;

--- a/src/ProjectOrigin.PedersenCommitment.Tests/SumProofTests.cs
+++ b/src/ProjectOrigin.PedersenCommitment.Tests/SumProofTests.cs
@@ -60,7 +60,7 @@ public class SumProofTests
         var c0 = pc_gens.Commit(42, r0);
         var c1 = pc_gens.Commit(42, r1);
 
-        var proof = EqualProof.Prove(pc_gens, r0, r1, label);
+        var proof = EqualProof.Prove(pc_gens, r0, r1, c0, c1, label);
 
         Assert.True(proof.Verify(pc_gens, c0, c1, label));
     }
@@ -101,7 +101,7 @@ public class SumProofTests
         var c2 = pc_gens.Commit(5, r2);
         var c3 = pc_gens.Commit(2, r3);
 
-        var proof = SumProof.Prove(pc_gens, label, r0, r1, r2, r3);
+        var proof = SumProof.Prove(pc_gens, label, r0, c0, (r1, c1), (r2, c2), (r3, c3));
         Assert.True(proof.Verify(pc_gens, label, c0, c1, c2, c3));
     }
 

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/Oracle.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/Oracle.cs
@@ -1,4 +1,5 @@
 namespace ProjectOrigin.PedersenCommitment.Ristretto;
+using System.Text;
 
 class Oracle
 {
@@ -8,6 +9,12 @@ class Oracle
     public Oracle(byte[] label)
     {
         messages.Add(label);
+    }
+
+    public void Domain(String domain)
+    {
+        var bytes = Encoding.UTF8.GetBytes("test");
+        messages.Add(bytes);
     }
 
 
@@ -20,7 +27,7 @@ class Oracle
         }
     }
 
-    public Scalar Hash()
+    public Scalar Challenge()
     {
         var m = 0;
         foreach (var msg in messages)

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/Oracle.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/Oracle.cs
@@ -1,0 +1,41 @@
+namespace ProjectOrigin.PedersenCommitment.Ristretto;
+
+class Oracle
+{
+
+    private List<byte[]> messages = new List<byte[]>();
+
+    public Oracle(byte[] label)
+    {
+        messages.Add(label);
+    }
+
+
+    public void Add(params Point[] points)
+    {
+
+        foreach (Point p in points)
+        {
+            messages.Add(p.Compress()._bytes);
+        }
+    }
+
+    public Scalar Hash()
+    {
+        var m = 0;
+        foreach (var msg in messages)
+        {
+            m += msg.Length;
+        }
+
+        var digest = new byte[m];
+        var begin = 0;
+        foreach (var msg in messages)
+        {
+
+            System.Array.Copy(msg, 0, digest, begin, msg.Length);
+            begin += msg.Length;
+        }
+        return Scalar.HashFromBytes(digest);
+    }
+}

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/Oracle.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/Oracle.cs
@@ -11,16 +11,10 @@ class Oracle
         messages.Add(label);
     }
 
-    public void Domain(String domain)
+    public void Add(String label, params Point[] points)
     {
-        var bytes = Encoding.UTF8.GetBytes("test");
+        var bytes = Encoding.UTF8.GetBytes(label);
         messages.Add(bytes);
-    }
-
-
-    public void Add(params Point[] points)
-    {
-
         foreach (Point p in points)
         {
             messages.Add(p.Compress()._bytes);

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/Point.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/Point.cs
@@ -36,6 +36,9 @@ public sealed class Point
         [DllImport("rust_ffi", EntryPoint = "ristretto_point_mul_scalar")]
         internal static extern IntPtr Mul(IntPtr point, IntPtr scalar);
 
+        [DllImport("rust_ffi", EntryPoint = "ristretto_point_sum")]
+        internal static extern IntPtr Sum(IntPtr[] args, int len);
+
         [DllImport("rust_ffi", EntryPoint = "ristretto_point_equals")]
         internal static extern bool Equals(IntPtr lhs, IntPtr rhs);
 
@@ -134,6 +137,16 @@ public sealed class Point
     public static bool operator !=(Point left, Point right)
     {
         return !Native.Equals(left._ptr, right._ptr);
+    }
+
+    public static Point Sum(params Point[] args)
+    {
+        var ptrs = new IntPtr[args.Length];
+        for (int i = 0; i < args.Length; i++)
+            ptrs[i] = args[i]._ptr;
+
+        var resPtr = Native.Sum(ptrs, ptrs.Length);
+        return new Point(resPtr);
     }
 
     public void GutSpill()

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/Point.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/Point.cs
@@ -45,6 +45,8 @@ public sealed class Point
 
     internal readonly IntPtr _ptr;
 
+    public readonly static int LENGTH = 32;
+
     internal Point(IntPtr ptr)
     {
         _ptr = ptr;

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/Scalar.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/Scalar.cs
@@ -182,7 +182,6 @@ public sealed class Scalar
 
     public static Scalar Sum(params Scalar[] args)
     {
-        args[0].SpillGuts();
         var ptrs = new IntPtr[args.Length];
         for (int i = 0; i < args.Length; i++)
             ptrs[i] = args[i]._ptr;

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/Scalar.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/Scalar.cs
@@ -36,6 +36,9 @@ public sealed class Scalar
         [DllImport("rust_ffi", EntryPoint = "scalar_mul")]
         internal static extern IntPtr Mul(IntPtr lhs, IntPtr rhs);
 
+        [DllImport("rust_ffi", EntryPoint = "scalar_sum")]
+        internal static extern IntPtr Sum(IntPtr[] args, int len);
+
         [DllImport("rust_ffi", EntryPoint = "scalar_equals")]
         internal static extern bool Equals(IntPtr lhs, IntPtr rhs);
 
@@ -175,6 +178,16 @@ public sealed class Scalar
         return !Native.Equals(left._ptr, right._ptr);
     }
 
-
     public override int GetHashCode() => base.GetHashCode();
+
+    public static Scalar Sum(params Scalar[] args)
+    {
+        args[0].SpillGuts();
+        var ptrs = new IntPtr[args.Length];
+        for (int i = 0; i < args.Length; i++)
+            ptrs[i] = args[i]._ptr;
+
+        var resPtr = Native.Sum(ptrs, ptrs.Length);
+        return new Scalar(resPtr);
+    }
 }

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
@@ -38,7 +38,7 @@ public class ZeroProof
         oracle.Add("domain_zeroproof");
         oracle.Add("message_A", A);
         oracle.Add("generator_GH", gen.G(), gen.H());
-        var c = oracle.Challenge();
+        var c = oracle.Challenge("challenge_c");
         var z = a - c * r;
         return new ZeroProof(c, z);
     }
@@ -63,7 +63,7 @@ public class ZeroProof
         oracle.Add("domain_zeroproof");
         oracle.Add("message_A", A);
         oracle.Add("generator_GH", gen.G(), gen.H());
-        var c = oracle.Challenge();
+        var c = oracle.Challenge("challenge_c");
         return this.c == c;
     }
 

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
@@ -27,7 +27,7 @@ public class ZeroProof
     {
         var c0 = gen.H() * r;
         var oracle = new Oracle(label);
-        oracle.Add(c0, gen.G(), gen.H());
+        oracle.Add(c0);
         return ZeroProof.Prove(gen, r, oracle);
     }
 
@@ -35,8 +35,9 @@ public class ZeroProof
     {
         var a = Scalar.Random();
         var A = gen.H() * a;
-        oracle.Add(A);
-        var c = oracle.Hash();
+        oracle.Domain("ZeroProof");
+        oracle.Add(A, gen.G(), gen.H());
+        var c = oracle.Challenge();
         var z = a - c * r;
         return new ZeroProof(c, z);
     }
@@ -51,15 +52,16 @@ public class ZeroProof
     public bool Verify(Generator gen, Point c0, byte[] label)
     {
         var oracle = new Oracle(label);
-        oracle.Add(c0, gen.G(), gen.H());
+        oracle.Add(c0);
         return this.Verify(gen, c0, oracle);
     }
 
     internal bool Verify(Generator gen, Point c0, Oracle oracle)
     {
         var A = (gen.H() * this.z) + (c0 * this.c);
-        oracle.Add(A);
-        var c = oracle.Hash();
+        oracle.Domain("ZeroProof");
+        oracle.Add(A, gen.G(), gen.H());
+        var c = oracle.Challenge();
         return this.c == c;
     }
 
@@ -104,7 +106,8 @@ public class EqualProof
     public static EqualProof Prove(Generator gen, Scalar r0, Scalar r1, Point c0, Point c1, byte[] label)
     {
         var oracle = new Oracle(label);
-        oracle.Add(c0, c1, gen.G(), gen.H());
+        oracle.Domain("EqualProof");
+        oracle.Add(c0, c1);
         return new EqualProof(ZeroProof.Prove(gen, r0 - r1, oracle));
     }
 
@@ -120,7 +123,8 @@ public class EqualProof
     public bool Verify(Generator gen, Point c0, Point c1, byte[] label)
     {
         var oracle = new Oracle(label);
-        oracle.Add(c0, c1, gen.G(), gen.H());
+        oracle.Domain("EqualProof");
+        oracle.Add(c0, c1);
         return proof.Verify(gen, c0 - c1, oracle);
     }
 
@@ -161,7 +165,8 @@ public class SumProof
         var rsum2 = Scalar.Sum(rs);
 
         var oracle = new Oracle(label);
-        oracle.Add(csum, gen.G(), gen.H());
+        oracle.Domain("SumProof");
+        oracle.Add(csum);
         foreach (var (_, p) in vec)
         {
             oracle.Add(p);
@@ -182,7 +187,8 @@ public class SumProof
         var csum2 = Point.Sum(cs);
 
         var oracle = new Oracle(label);
-        oracle.Add(csum, gen.G(), gen.H());
+        oracle.Domain("SumProof");
+        oracle.Add(csum);
         oracle.Add(cs);
         return proof.Verify(gen, csum - csum2, oracle);
     }

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
@@ -26,15 +26,17 @@ public class ZeroProof
     public static ZeroProof Prove(Generator gen, Scalar r, byte[] label)
     {
         var c0 = gen.H() * r;
-        var oracle = (Point A) => Oracle(label, A, c0, gen.G(), gen.H());
+        var oracle = new Oracle(label);
+        oracle.Add(c0, gen.G(), gen.H());
         return ZeroProof.Prove(gen, r, oracle);
     }
 
-    internal static ZeroProof Prove(Generator gen, Scalar r, Func<Point, Scalar> oracle)
+    internal static ZeroProof Prove(Generator gen, Scalar r, Oracle oracle)
     {
         var a = Scalar.Random();
         var A = gen.H() * a;
-        var c = oracle(A);
+        oracle.Add(A);
+        var c = oracle.Hash();
         var z = a - c * r;
         return new ZeroProof(c, z);
     }
@@ -48,29 +50,17 @@ public class ZeroProof
     /// <returns>true if the commitment is made to zero and the proof holds</returns>
     public bool Verify(Generator gen, Point c0, byte[] label)
     {
-        return this.Verify(gen, c0, (A) => Oracle(label, A, c0, gen.G(), gen.H()));
+        var oracle = new Oracle(label);
+        oracle.Add(c0, gen.G(), gen.H());
+        return this.Verify(gen, c0, oracle);
     }
 
-    internal bool Verify(Generator gen, Point c0, Func<Point, Scalar> oracle)
+    internal bool Verify(Generator gen, Point c0, Oracle oracle)
     {
         var A = (gen.H() * this.z) + (c0 * this.c);
-        var c = oracle(A);
+        oracle.Add(A);
+        var c = oracle.Hash();
         return this.c == c;
-    }
-
-    internal static Scalar Oracle(byte[] label, params Point[] inputs)
-    {
-        var m = (inputs.Length * Point.LENGTH) + label.Length;
-        var digest = new byte[m];
-        var begin = 0;
-        foreach (var point in inputs)
-        {
-            var item = point.Compress()._bytes;
-            System.Array.Copy(item, 0, digest, begin, item.Length);
-            begin += item.Length;
-        }
-        System.Array.Copy(label, 0, digest, begin, label.Length);
-        return Scalar.HashFromBytes(digest);
     }
 
     public byte[] Serialize()
@@ -113,7 +103,8 @@ public class EqualProof
     /// <returns>a new proof</returns>
     public static EqualProof Prove(Generator gen, Scalar r0, Scalar r1, Point c0, Point c1, byte[] label)
     {
-        var oracle = (Point A) => ZeroProof.Oracle(label, A, c0, c1, gen.G(), gen.H());
+        var oracle = new Oracle(label);
+        oracle.Add(c0, c1, gen.G(), gen.H());
         return new EqualProof(ZeroProof.Prove(gen, r0 - r1, oracle));
     }
 
@@ -128,7 +119,8 @@ public class EqualProof
     /// <returns>true if the commitments are to the same value and the proof holds</returns>
     public bool Verify(Generator gen, Point c0, Point c1, byte[] label)
     {
-        var oracle = (Point A) => ZeroProof.Oracle(label, A, c0, c1, gen.G(), gen.H());
+        var oracle = new Oracle(label);
+        oracle.Add(c0, c1, gen.G(), gen.H());
         return proof.Verify(gen, c0 - c1, oracle);
     }
 
@@ -168,18 +160,12 @@ public class SumProof
             rs[i] = vec[i].Item1;
         var rsum2 = Scalar.Sum(rs);
 
-
-        var oracle = (Point A) =>
+        var oracle = new Oracle(label);
+        oracle.Add(csum, gen.G(), gen.H());
+        foreach (var (_, p) in vec)
         {
-            var n = vec.Length;
-            var args = new Point[n + 3];
-            for (int i = 0; i < n; i++)
-                args[i] = vec[i].Item2;
-            args[n] = gen.G();
-            args[n + 1] = gen.H();
-            args[n + 2] = A;
-            return ZeroProof.Oracle(label, args);
-        };
+            oracle.Add(p);
+        }
         return new SumProof(ZeroProof.Prove(gen, rsum - rsum2, oracle));
     }
 
@@ -195,16 +181,9 @@ public class SumProof
     {
         var csum2 = Point.Sum(cs);
 
-        var oracle = (Point A) =>
-        {
-            var n = cs.Length;
-            var args = new Point[n + 3];
-            System.Array.Copy(cs, 0, args, 0, n);
-            args[n] = gen.G();
-            args[n + 1] = gen.H();
-            args[n + 2] = A;
-            return ZeroProof.Oracle(label, args);
-        };
+        var oracle = new Oracle(label);
+        oracle.Add(csum, gen.G(), gen.H());
+        oracle.Add(cs);
         return proof.Verify(gen, csum - csum2, oracle);
     }
 

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
@@ -27,7 +27,7 @@ public class ZeroProof
     {
         var a = Scalar.Random();
         var A = gen.H() * a;
-        var c = Oracle(label, A, gen.G(), gen.H());
+        var c = Oracle(label, A, gen.H() * r, gen.G(), gen.H());
         var z = a - c * r;
         return new ZeroProof(c, z);
     }
@@ -42,14 +42,13 @@ public class ZeroProof
     public bool Verify(Generator gen, Point c0, byte[] label)
     {
         var A = (gen.H() * this.z) + (c0 * this.c);
-        var c = Oracle(label, A, gen.G(), gen.H());
+        var c = Oracle(label, A, c0, gen.G(), gen.H());
         return this.c == c;
     }
 
     private static Scalar Oracle(byte[] label, params Point[] inputs)
     {
         var m = (inputs.Length * Point.LENGTH) + label.Length;
-
         var digest = new byte[m];
         var begin = 0;
         foreach (var point in inputs)

--- a/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
+++ b/src/ProjectOrigin.PedersenCommitment/Ristretto/SigmaProof.cs
@@ -163,11 +163,10 @@ public class SumProof
     /// <returns>a new proof</returns>
     public static SumProof Prove(Generator gen, byte[] label, Scalar rsum, Point csum, params (Scalar, Point)[] vec)
     {
-        var rsum2 = vec[0].Item1;
-        foreach ((Scalar, Point) item in vec[1..])
-        { // TODO: Probably use a Native function for speedup
-            rsum2 += item.Item1;
-        }
+        var rs = new Scalar[vec.Length];
+        for (int i = 0; i < vec.Length; i++)
+            rs[i] = vec[i].Item1;
+        var rsum2 = Scalar.Sum(rs);
 
 
         var oracle = (Point A) =>
@@ -194,11 +193,7 @@ public class SumProof
     /// <returns>true of the commitments are made to the commitment sum</returns>
     public bool Verify(Generator gen, byte[] label, Point csum, params Point[] cs)
     {
-        var csum2 = cs[0];
-        foreach (Point r in cs[1..])
-        { // TODO: Probably use a Native function for speedup
-            csum2 += r;
-        }
+        var csum2 = Point.Sum(cs);
 
         var oracle = (Point A) =>
         {

--- a/src/ProjectOrigin.PedersenCommitment/SecretCommitmentInfo.cs
+++ b/src/ProjectOrigin.PedersenCommitment/SecretCommitmentInfo.cs
@@ -42,7 +42,7 @@ public record SecretCommitmentInfo
     public static ReadOnlySpan<byte> CreateEqualityProof(SecretCommitmentInfo left, SecretCommitmentInfo right, string label)
     {
         var labelBytes = Encoding.UTF8.GetBytes(label);
-        var equalityProof = Ristretto.EqualProof.Prove(Generator.Default, left._blindingValue, right._blindingValue, labelBytes);
+        var equalityProof = Ristretto.EqualProof.Prove(Generator.Default, left._blindingValue, right._blindingValue, left.Commitment.Point, right.Commitment.Point, labelBytes);
         return equalityProof.Serialize();
     }
 

--- a/src/rust-ffi/src/lib.rs
+++ b/src/rust-ffi/src/lib.rs
@@ -9,6 +9,7 @@ pub mod point;
 pub mod rangeproof;
 pub mod scalar;
 mod util;
+pub mod transscript;
 
 #[no_mangle]
 pub unsafe extern "C" fn fill_bytes(raw: *const RawVec<u8>, dst: *mut u8) {

--- a/src/rust-ffi/src/point.rs
+++ b/src/rust-ffi/src/point.rs
@@ -97,6 +97,15 @@ pub extern "C" fn ristretto_point_mul_scalar(
 }
 
 #[no_mangle]
+pub extern "C" fn ristretto_point_sum(
+    args: *const *const RistrettoPoint,
+    len: i32,
+) -> *const RistrettoPoint {
+    let args = unsafe { std::slice::from_raw_parts(args, len as usize) };
+    Box::into_raw(Box::new(args.iter().map(|&ptr| unsafe { *ptr }).sum()))
+}
+
+#[no_mangle]
 pub extern "C" fn ristretto_point_free(this: *mut RistrettoPoint) {
     if this.is_null() {
         return;

--- a/src/rust-ffi/src/scalar.rs
+++ b/src/rust-ffi/src/scalar.rs
@@ -75,6 +75,12 @@ pub unsafe extern "C" fn scalar_mul(lhs: *const Scalar, rhs: *const Scalar) -> *
 }
 
 #[no_mangle]
+pub extern "C" fn scalar_sum(args: *const *const Scalar, len: i32) -> *const Scalar {
+    let args = unsafe { std::slice::from_raw_parts(args, len as usize) };
+    Box::into_raw(Box::new(args.iter().map(|&ptr| unsafe { *ptr }).sum()))
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn scalar_free(this: *mut Scalar) {
     if this.is_null() {
         return;

--- a/src/rust-ffi/src/transscript.rs
+++ b/src/rust-ffi/src/transscript.rs
@@ -1,0 +1,53 @@
+use core::slice;
+
+use curve25519_dalek_ng::{ristretto::RistrettoPoint, scalar::Scalar};
+use merlin::Transcript;
+
+use crate::deref;
+
+
+#[no_mangle]
+pub unsafe extern "C" fn transcript_new(label: *const u8, len: usize) -> *const Transcript {
+    let label = slice::from_raw_parts(label, len);
+    Box::into_raw(Box::new(Transcript::new(label)))
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn transcript_append_point(
+    this: *mut Transcript,
+    label: *const u8,
+    len: usize,
+    point: *const RistrettoPoint
+) {
+    let label = slice::from_raw_parts(label, len);
+    let point = deref!(point);
+    (*this).append_message(label, point.compress().as_bytes());
+}
+
+
+#[no_mangle]
+pub unsafe extern "C" fn transcript_domain(
+    this: *mut Transcript,
+    message: *const u8,
+    len: usize,
+) {
+    let message = slice::from_raw_parts(message, len);
+    (*this).append_message(b"domain-sep", message)
+}
+
+
+
+#[no_mangle]
+pub unsafe extern "C" fn transcript_challenge_scalar(
+    this: *mut Transcript,
+    label: *const u8,
+    len: usize,
+) -> *const Scalar {
+    let mut buf = [0u8; 64];
+    let label = slice::from_raw_parts(label, len);
+    (*this).challenge_bytes(label, &mut buf);
+
+    let scalar = Scalar::from_bytes_mod_order_wide(&buf);
+    Box::into_raw(Box::new(scalar))
+}


### PR DESCRIPTION
Add binding of the public part of commitments to the Oracle, thus preventing someone from replacing the commitment(s) associated with the proof.

Also implement a native sum function (solving #78 and #79) for RistrettoPoints and Scalars to avoid needless allocation for every intermediate value. This also (as a side-effect) fixes a part where the first element was silently mutated as a side effect.