### PR TITLE
Add latest rust to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,11 @@
         "dockerfile": "Dockerfile"
     },
     // Features to add to the dev container. More info: https://containers.dev/features.
-    "features": {},
+    "features": {
+        "ghcr.io/devcontainers/features/rust:1": {
+            "version": "latest"
+        }
+    },
     // Use 'forwardPorts' to make a list of ports inside the container available locally.
     // "forwardPorts": [5000, 5001],
     // Use 'postCreateCommand' to run commands after the container is created.


### PR DESCRIPTION
Install rust into the devcontainer so it´s possible to build the projects out of the box.