### PR TITLE
Embedded commitment library

### DIFF
--- a/src/ProjectOrigin.Electricity.Client/ProjectOrigin.Electricity.Client.csproj
+++ b/src/ProjectOrigin.Electricity.Client/ProjectOrigin.Electricity.Client.csproj
@@ -2,7 +2,7 @@
 
   <ItemGroup>
     <PackageReference Include="NSec.Cryptography" Version="22.4.0" />
-    <ProjectReference Include="..\ProjectOrigin.PedersenCommitment\ProjectOrigin.PedersenCommitment.csproj" />
+    <ProjectReference Include="..\ProjectOrigin.PedersenCommitment\ProjectOrigin.PedersenCommitment.csproj" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I have embedded the commitment library into the electricity client library for now.

We can always later separate it into a separate Nuget package, for now not having separate life cycles of the packages are easier for us to upkeep.