### PR TITLE
CommandStatusEvent constructor made public

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: Setup .NET Core SDK 7
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "7.0"
+          dotnet-version: "7.0.203"
 
       - name: Install windows cross-compile
         run: |

--- a/.github/workflows/dotnet-formatting.yml
+++ b/.github/workflows/dotnet-formatting.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup .NET Core SDK 7
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "7.0"
+          dotnet-version: "7.0.203"
 
       - name: Verify formatting
         run: make verify

--- a/src/ProjectOrigin.Electricity.Client/Models/CommandStatusEvent.cs
+++ b/src/ProjectOrigin.Electricity.Client/Models/CommandStatusEvent.cs
@@ -21,7 +21,13 @@ public class CommandStatusEvent
     /// </summary>
     public string? Error { get; }
 
-    internal CommandStatusEvent(CommandId id, CommandState state, string? error)
+    /// <summary>
+    /// Constructor for CommandStatusEvent.
+    /// </summary>
+    /// <param name="id">The ID/CommandReference to the command the update relates to.</param>
+    /// <param name="state">The actual state the command is in, on the registry.</param>
+    /// <param name="error">If the CommandState is Failed, then this value will contain the message associated with the failure.</param>
+    public CommandStatusEvent(CommandId id, CommandState state, string? error)
     {
         Id = id;
         State = state;


### PR DESCRIPTION
CommandStatusEvent constructor made public so that it can be instantiated by unit tests in other projects.