### PR TITLE
Fix sonarcloud code smells

### DIFF
--- a/src/ProjectOrigin.Electricity.Example/ProtoEventBuilder.cs
+++ b/src/ProjectOrigin.Electricity.Example/ProtoEventBuilder.cs
@@ -73,7 +73,7 @@ public class ProtoEventBuilder
         return @event;
     }
 
-    public Electricity.V1.SlicedEvent CreateSliceEvent(FederatedStreamId certId, IPublicKey newOwnerKey, SecretCommitmentInfo sourceSlice, params SecretCommitmentInfo[] slices)
+    public static Electricity.V1.SlicedEvent CreateSliceEvent(FederatedStreamId certId, IPublicKey newOwnerKey, SecretCommitmentInfo sourceSlice, params SecretCommitmentInfo[] slices)
     {
         var sumOfNewSlices = slices.Aggregate((left, right) => left + right);
         var equalityProof = SecretCommitmentInfo.CreateEqualityProof(sourceSlice, sumOfNewSlices, certId.StreamId.Value);
@@ -101,7 +101,7 @@ public class ProtoEventBuilder
         return @event;
     }
 
-    public Electricity.V1.AllocatedEvent CreateAllocatedEvent(Guid allocationId, FederatedStreamId prodCertId, FederatedStreamId consCertId, SecretCommitmentInfo prodComtInfo, SecretCommitmentInfo consComtInfo)
+    public static Electricity.V1.AllocatedEvent CreateAllocatedEvent(Guid allocationId, FederatedStreamId prodCertId, FederatedStreamId consCertId, SecretCommitmentInfo prodComtInfo, SecretCommitmentInfo consComtInfo)
     {
         var equalityProof = SecretCommitmentInfo.CreateEqualityProof(prodComtInfo, consComtInfo, allocationId.ToString());
 
@@ -116,7 +116,7 @@ public class ProtoEventBuilder
         };
     }
 
-    public Electricity.V1.ClaimedEvent CreateClaimEvent(Guid allocationId, FederatedStreamId certificateId)
+    public static Electricity.V1.ClaimedEvent CreateClaimEvent(Guid allocationId, FederatedStreamId certificateId)
     {
         return new Electricity.V1.ClaimedEvent
         {
@@ -125,7 +125,7 @@ public class ProtoEventBuilder
         };
     }
 
-    public FederatedStreamId ToCertId(string registry, Guid certId)
+    public static FederatedStreamId ToCertId(string registry, Guid certId)
     {
         return new Common.V1.FederatedStreamId
         {
@@ -146,7 +146,7 @@ public class ProtoEventBuilder
         };
     }
 
-    private ByteString ToSliceId(PedersenCommitment.Commitment commitment)
+    private static ByteString ToSliceId(PedersenCommitment.Commitment commitment)
     {
         return ByteString.CopyFrom(SHA256.HashData(commitment.C));
     }

--- a/src/ProjectOrigin.Electricity.Example/WithoutWalletFlow.cs
+++ b/src/ProjectOrigin.Electricity.Example/WithoutWalletFlow.cs
@@ -1,10 +1,15 @@
 using System;
+using System.Reflection.Emit;
 using System.Text;
 using System.Threading.Tasks;
 using Grpc.Net.Client;
+using ProjectOrigin.Common.V1;
 using ProjectOrigin.Electricity.Example.Extensions;
+using ProjectOrigin.Electricity.V1;
 using ProjectOrigin.HierarchicalDeterministicKeys;
+using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 using ProjectOrigin.PedersenCommitment;
+using ProjectOrigin.Registry.V1;
 using RegistryV1 = ProjectOrigin.Registry.V1;
 
 namespace ProjectOrigin.Electricity.Example;
@@ -48,102 +53,106 @@ public class WithoutWalletFlow
 
         // ------------------  Issue Consumption ------------------
         // Create a new ConsumptionIssuedEvent, sign it and sent it to the registry.
-        var consCertId = eventBuilder.ToCertId(ConsRegistryName, Guid.NewGuid());
+        var consCertId = ProtoEventBuilder.ToCertId(ConsRegistryName, Guid.NewGuid());
         var consCommitmentInfo = new SecretCommitmentInfo(250);
-        {
-            Console.WriteLine($"Issuing consumption Granular Certificate");
-            var consumptionIssued = eventBuilder.CreateConsumptionIssuedEvent(consCertId, consCommitmentInfo, ownerKey.PublicKey);
-
-            // Sign the event as a transaction
-            var signedTransaction = issuerKey.SignTransaction(consumptionIssued.CertificateId, consumptionIssued);
-
-            // Send transaction to registry, and wait for committed state
-            await consClient.SendTransactionAndWait(signedTransaction);
-        }
+        Console.WriteLine($"Issuing consumption Granular Certificate");
+        await IssueConsumptionCertificate(ownerKey, issuerKey, consClient, eventBuilder, consCertId, consCommitmentInfo);
 
 
         // ------------------  Issue production ------------------
         // Create a new ProductionIssuedEvent, sign it and sent it to the registry.
-        var prodCertId = eventBuilder.ToCertId(ProdRegistryName, Guid.NewGuid());
+        var prodCertId = ProtoEventBuilder.ToCertId(ProdRegistryName, Guid.NewGuid());
         var prodCommitmentInfo = new SecretCommitmentInfo(350);
-        {
-            Console.WriteLine($"Issuing Production Granular Certificate");
-            var productionIssued = eventBuilder.CreateProductionIssuedEvent(prodCertId, prodCommitmentInfo, ownerKey.PublicKey);
-
-            // Sign the event as a transaction
-            var signedTransaction = issuerKey.SignTransaction(productionIssued.CertificateId, productionIssued);
-
-            // Send transaction to registry, and wait for committed state
-            await prodClient.SendTransactionAndWait(signedTransaction);
-        }
+        Console.WriteLine($"Issuing Production Granular Certificate");
+        await IssueProductionCertificate(ownerKey, issuerKey, prodClient, eventBuilder, prodCertId, prodCommitmentInfo);
 
 
         // ------------------  slice production ------------------
         // define slice commitments
         var prodCommitment250 = new SecretCommitmentInfo(250);
         var prodCommitment100 = new SecretCommitmentInfo(100);
-        {
-            Console.WriteLine($"Slicing Production Granular Certificate");
-            //create slice event, that enables the production certificate to be sliced
-            var productionSliceEvent = eventBuilder.CreateSliceEvent(prodCertId, ownerKey.PublicKey, prodCommitmentInfo, prodCommitment250, prodCommitment100);
-
-            // Sign the event as a transaction
-            var signedTransaction = ownerKey.SignTransaction(productionSliceEvent.CertificateId, productionSliceEvent);
-
-            // Send transaction to registry, and wait for committed state
-            await prodClient.SendTransactionAndWait(signedTransaction);
-        }
+        Console.WriteLine($"Slicing Production Granular Certificate");
+        await SliceCertificate(ownerKey, prodClient, prodCertId, prodCommitmentInfo, prodCommitment250, prodCommitment100);
 
 
-        // ------------------  allocate production ------------------
+        // ------------------  allocate ------------------
+        Console.WriteLine($"Allocating Production Granular Certificate");
         var allocationId = Guid.NewGuid();
-        {
-            Console.WriteLine($"Allocating Production Granular Certificate");
+        var allocatedEvent = ProtoEventBuilder.CreateAllocatedEvent(allocationId, prodCertId, consCertId, prodCommitment250, consCommitmentInfo);
 
-            // Create allocation event, this can be used for both Certificates
-            var allocatedEvent = eventBuilder.CreateAllocatedEvent(allocationId, prodCertId, consCertId, prodCommitment250, consCommitmentInfo);
 
-            // Sign the event as a transaction to the production certificate
-            var prodAllocationSignedTransaction = ownerKey.SignTransaction(allocatedEvent.ProductionCertificateId, allocatedEvent);
+        // ------------------ allocate production ------------------
+        Console.WriteLine($"Allocating Production Granular Certificate");
+        await SendAllocation(ownerKey, prodClient, allocatedEvent, allocatedEvent.ProductionCertificateId);
 
-            // Send transaction to registry, and wait for committed state
-            await prodClient.SendTransactionAndWait(prodAllocationSignedTransaction);
 
-            // ------------------ allocate consumption ------------------
-            Console.WriteLine($"Allocating Consumption Granular Certificate");
-
-            // Sign the event as a transaction to the consumption certificate
-            var consAllocationSignedTransaction = ownerKey.SignTransaction(allocatedEvent.ConsumptionCertificateId, allocatedEvent);
-
-            // Send transaction to registry, and wait for committed state
-            await consClient.SendTransactionAndWait(consAllocationSignedTransaction);
-        }
+        // ------------------ allocate consumption ------------------
+        Console.WriteLine($"Allocating Consumption Granular Certificate");
+        await SendAllocation(ownerKey, consClient, allocatedEvent, allocatedEvent.ConsumptionCertificateId);
 
 
         // ------------------  claim production ------------------
-        {
-            Console.WriteLine($"Claiming Production Granular Certificate");
-            var productionClaimEvent = eventBuilder.CreateClaimEvent(allocationId, prodCertId);
+        Console.WriteLine($"Claiming Production Granular Certificate");
+        await NewMethod(ownerKey, prodClient, prodCertId, allocationId);
 
-            // Sign the event as a transaction
-            var signedTransaction = ownerKey.SignTransaction(productionClaimEvent.CertificateId, productionClaimEvent);
-
-            // Send transaction to registry, and wait for committed state
-            await prodClient.SendTransactionAndWait(signedTransaction);
-        }
 
         // ------------------  claim consumption ------------------
-        {
-            Console.WriteLine($"Claiming Consumption Granular Certificate");
-            var consumptionClaimEvent = eventBuilder.CreateClaimEvent(allocationId, consCertId);
-
-            // Sign the event as a transaction
-            var signedTransaction = ownerKey.SignTransaction(consumptionClaimEvent.CertificateId, consumptionClaimEvent);
-
-            // Send transaction to registry, and wait for committed state
-            await consClient.SendTransactionAndWait(signedTransaction);
-        }
+        Console.WriteLine($"Claiming Consumption Granular Certificate");
+        await NewMethod(ownerKey, consClient, consCertId, allocationId);
 
         return 0;
+    }
+
+    private static async Task NewMethod(IHDPrivateKey ownerKey, RegistryService.RegistryServiceClient prodClient, FederatedStreamId prodCertId, Guid allocationId)
+    {
+        var productionClaimEvent = ProtoEventBuilder.CreateClaimEvent(allocationId, prodCertId);
+
+        // Sign the event as a transaction
+        var signedTransaction = ownerKey.SignTransaction(productionClaimEvent.CertificateId, productionClaimEvent);
+
+        // Send transaction to registry, and wait for committed state
+        await prodClient.SendTransactionAndWait(signedTransaction);
+    }
+
+    private static async Task SendAllocation(IHDPrivateKey ownerKey, RegistryService.RegistryServiceClient prodClient, AllocatedEvent allocatedEvent, FederatedStreamId certificateId)
+    {
+        // Sign the event as a transaction to the production certificate
+        var prodAllocationSignedTransaction = ownerKey.SignTransaction(certificateId, allocatedEvent);
+
+        // Send transaction to registry, and wait for committed state
+        await prodClient.SendTransactionAndWait(prodAllocationSignedTransaction);
+    }
+
+    private static async Task IssueConsumptionCertificate(IHDPrivateKey ownerKey, IPrivateKey issuerKey, RegistryService.RegistryServiceClient consClient, ProtoEventBuilder eventBuilder, FederatedStreamId consCertId, SecretCommitmentInfo consCommitmentInfo)
+    {
+        var consumptionIssued = eventBuilder.CreateConsumptionIssuedEvent(consCertId, consCommitmentInfo, ownerKey.PublicKey);
+
+        // Sign the event as a transaction
+        var signedTransaction = issuerKey.SignTransaction(consumptionIssued.CertificateId, consumptionIssued);
+
+        // Send transaction to registry, and wait for committed state
+        await consClient.SendTransactionAndWait(signedTransaction);
+    }
+
+    private static async Task IssueProductionCertificate(IHDPrivateKey ownerKey, IPrivateKey issuerKey, RegistryService.RegistryServiceClient prodClient, ProtoEventBuilder eventBuilder, FederatedStreamId prodCertId, SecretCommitmentInfo prodCommitmentInfo)
+    {
+        var productionIssued = eventBuilder.CreateProductionIssuedEvent(prodCertId, prodCommitmentInfo, ownerKey.PublicKey);
+
+        // Sign the event as a transaction
+        var signedTransaction = issuerKey.SignTransaction(productionIssued.CertificateId, productionIssued);
+
+        // Send transaction to registry, and wait for committed state
+        await prodClient.SendTransactionAndWait(signedTransaction);
+    }
+
+    private static async Task SliceCertificate(IHDPrivateKey ownerKey, RegistryService.RegistryServiceClient prodClient, FederatedStreamId prodCertId, SecretCommitmentInfo prodCommitmentInfo, SecretCommitmentInfo prodCommitment250, SecretCommitmentInfo prodCommitment100)
+    {
+        var productionSliceEvent = ProtoEventBuilder.CreateSliceEvent(prodCertId, ownerKey.PublicKey, prodCommitmentInfo, prodCommitment250, prodCommitment100);
+
+        // Sign the event as a transaction
+        var signedTransaction = ownerKey.SignTransaction(productionSliceEvent.CertificateId, productionSliceEvent);
+
+        // Send transaction to registry, and wait for committed state
+        await prodClient.SendTransactionAndWait(signedTransaction);
     }
 }

--- a/src/ProjectOrigin.Electricity.IntegrationTests/ExceptionTest.cs
+++ b/src/ProjectOrigin.Electricity.IntegrationTests/ExceptionTest.cs
@@ -94,7 +94,7 @@ public class ExceptionTest : GrpcTestBase<Startup>
         result.Valid.Should().BeFalse();
     }
 
-    private VerifyTransactionRequest CreateInvalidSignedEvent(IPrivateKey signerKey, IMessage @event, string type)
+    private static VerifyTransactionRequest CreateInvalidSignedEvent(IPrivateKey signerKey, IMessage @event, string type)
     {
         var header = new Registry.V1.TransactionHeader()
         {

--- a/src/ProjectOrigin.Electricity.IntegrationTests/FlowTests.cs
+++ b/src/ProjectOrigin.Electricity.IntegrationTests/FlowTests.cs
@@ -103,7 +103,7 @@ public class FlowTests : GrpcTestBase<Startup>
         return result;
     }
 
-    private Registry.V1.Transaction SignEvent(Common.V1.FederatedStreamId streamId, IMessage @event, IPrivateKey signerKey)
+    private static Registry.V1.Transaction SignEvent(Common.V1.FederatedStreamId streamId, IMessage @event, IPrivateKey signerKey)
     {
         var header = new Registry.V1.TransactionHeader()
         {

--- a/src/ProjectOrigin.Electricity.Server/ElectricityVerifierService.cs
+++ b/src/ProjectOrigin.Electricity.Server/ElectricityVerifierService.cs
@@ -29,10 +29,10 @@ internal class ElectricityVerifierService : VerifierService.VerifierServiceBase
                 Valid = true
             };
 
-            if (result is VerificationResult.Invalid)
+            if (result is VerificationResult.Invalid invalidResult)
             {
                 response.Valid = false;
-                response.ErrorMessage = ((VerificationResult.Invalid)result).ErrorMessage;
+                response.ErrorMessage = invalidResult.ErrorMessage;
             }
 
             return response;

--- a/src/ProjectOrigin.Electricity.Server/Exceptions/InvalidConfigurationException.cs
+++ b/src/ProjectOrigin.Electricity.Server/Exceptions/InvalidConfigurationException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ProjectOrigin.Electricity.Server.Exceptions;
+
+public class InvalidConfigurationException : Exception
+{
+    public InvalidConfigurationException(string? message) : base(message)
+    {
+    }
+
+    public InvalidConfigurationException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/ProjectOrigin.Electricity.Server/Extensions/IConfigurationExtensions.cs
+++ b/src/ProjectOrigin.Electricity.Server/Extensions/IConfigurationExtensions.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using ProjectOrigin.Electricity.Server;
+using ProjectOrigin.Electricity.Server.Exceptions;
 using Serilog;
 using Serilog.Enrichers.Span;
 using Serilog.Formatting.Json;
@@ -47,7 +48,7 @@ public static class IConfigurationExtensions
                 break;
 
             default:
-                throw new ArgumentOutOfRangeException("LogOutputFormat", "Invalid log output format.");
+                throw new InvalidConfigurationException("Invalid log output format.");
         }
 
         return loggerConfiguration.CreateLogger();

--- a/src/ProjectOrigin.Electricity.Server/Interfaces/IModelHydrater.cs
+++ b/src/ProjectOrigin.Electricity.Server/Interfaces/IModelHydrater.cs
@@ -4,6 +4,6 @@ namespace ProjectOrigin.Electricity.Server.Interfaces;
 
 public interface IModelHydrater
 {
-    T HydrateModel<T>(IEnumerable<object> eventStream) where T : class;
+    T? HydrateModel<T>(IEnumerable<object> eventStream) where T : class;
     object? HydrateModel(IEnumerable<object> eventStream);
 }

--- a/src/ProjectOrigin.Electricity.Server/Services/AbstractModelHydrator.cs
+++ b/src/ProjectOrigin.Electricity.Server/Services/AbstractModelHydrator.cs
@@ -9,9 +9,9 @@ public abstract class AbstractModelHydrator : IModelHydrater
 {
     protected const string ApplyMethodName = "Apply";
 
-    public T HydrateModel<T>(IEnumerable<object> eventStream) where T : class
+    public T? HydrateModel<T>(IEnumerable<object> eventStream) where T : class
     {
-        return HydrateModel(eventStream) as T ?? throw new NullReferenceException("Hydrated model is null");
+        return HydrateModel(eventStream) as T;
     }
 
     public object? HydrateModel(IEnumerable<object> eventStream)

--- a/src/ProjectOrigin.Electricity.Server/Services/AbstractModelHydrator.cs
+++ b/src/ProjectOrigin.Electricity.Server/Services/AbstractModelHydrator.cs
@@ -11,7 +11,7 @@ public abstract class AbstractModelHydrator : IModelHydrater
 
     public T HydrateModel<T>(IEnumerable<object> eventStream) where T : class
     {
-        return HydrateModel(eventStream) as T ?? throw new Exception();
+        return HydrateModel(eventStream) as T ?? throw new NullReferenceException("Hydrated model is null");
     }
 
     public object? HydrateModel(IEnumerable<object> eventStream)

--- a/src/ProjectOrigin.Electricity.Server/Services/GrpcRemoteModelLoader.cs
+++ b/src/ProjectOrigin.Electricity.Server/Services/GrpcRemoteModelLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Net.Client;
@@ -30,7 +31,7 @@ public class GrpcRemoteModelLoader : IRemoteModelLoader
         }
         else
         {
-            throw new Exception($"Registry ”{registryName}” not known");
+            throw new KeyNotFoundException($"Registry ”{registryName}” not known");
         }
     }
 

--- a/src/ProjectOrigin.Electricity.Server/Services/VerifierDispatcher.cs
+++ b/src/ProjectOrigin.Electricity.Server/Services/VerifierDispatcher.cs
@@ -41,7 +41,6 @@ public class VerifierDispatcher : IVerifierDispatcher
         var methodInfo = verifier.GetType().GetMethod(VerifyMethodName) ??
             throw new NotImplementedException($"Could not find ”{VerifyMethodName}” method for type ”{transaction.Header.PayloadType}”");
 
-        return methodInfo.Invoke(verifier, new object[] { transaction, model!, @event }) as Task<VerificationResult>
-            ?? throw new Exception("Imposible exception, result is wrong type");
+        return (Task<VerificationResult>)methodInfo.Invoke(verifier, new object[] { transaction, model!, @event })!;
     }
 }

--- a/src/ProjectOrigin.Electricity.Server/Startup.cs
+++ b/src/ProjectOrigin.Electricity.Server/Startup.cs
@@ -17,8 +17,7 @@ public class Startup
     {
         services.AddGrpc();
 
-        services.AddSingleton<IProtoDeserializer>(new ProtoDeserializer(Assembly.GetAssembly(typeof(V1.IssuedEvent))
-            ?? throw new Exception("Could not find assembly")));
+        services.AddSingleton<IProtoDeserializer>(new ProtoDeserializer(Assembly.GetAssembly(typeof(V1.IssuedEvent))!));
 
         services.AddTransient<IEventVerifier<V1.IssuedEvent>, IssuedEventVerifier>();
         services.AddTransient<IEventVerifier<V1.AllocatedEvent>, AllocatedEventVerifier>();

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
@@ -26,10 +26,6 @@ public class IssuedEventVerifier : IEventVerifier<V1.IssuedEvent>
         if (payload.Type == V1.GranularCertificateType.Invalid)
             return new VerificationResult.Invalid("Invalid certificate type");
 
-        // if (payload.QuantityPublication is not null
-        //     && !payload.QuantityCommitment.VerifyPublication(payload.QuantityPublication))
-        //     return new VerificationResult.Invalid($"Private and public quantity proof does not match");
-
         if (!payload.OwnerPublicKey.TryToModel(out _))
             return new VerificationResult.Invalid("Invalid owner key, not a valid publicKey");
 

--- a/src/ProjectOrigin.Electricity/Models/GranularCertificate.cs
+++ b/src/ProjectOrigin.Electricity/Models/GranularCertificate.cs
@@ -36,12 +36,12 @@ public class GranularCertificate
         else if (_issued.Type == V1.GranularCertificateType.Consumption)
             AllocateSlice(e.ConsumptionSourceSliceHash, e);
         else
-            throw new NotSupportedException($"Certificate type ”{_issued.Type.ToString()}” is not supported");
+            throw new NotSupportedException($"Certificate type ”{_issued.Type}” is not supported");
     }
 
     public void Apply(V1.ClaimedEvent e)
     {
-        var slice = GetAllocation(e.AllocationId) ?? throw new Exception("Invalid state");
+        var slice = GetAllocation(e.AllocationId) ?? throw new KeyNotFoundException($"allocation not found ”{e.AllocationId}” - Invalid state");
         _allocationSlices.Remove(e.AllocationId);
         _claimedSlices.Add(e.AllocationId, slice);
     }
@@ -62,7 +62,7 @@ public class GranularCertificate
 
     protected CertificateSlice TakeAvailableSlice(ByteString sliceHash)
     {
-        var oldSlice = GetCertificateSlice(sliceHash) ?? throw new Exception("Invalid state");
+        var oldSlice = GetCertificateSlice(sliceHash) ?? throw new KeyNotFoundException($"slice not found ”{sliceHash}” - Invalid state");
         _availableSlices.Remove(sliceHash);
         return oldSlice;
     }

--- a/src/ProjectOrigin.Registry.Server/Exceptions/DatabaseStateException.cs
+++ b/src/ProjectOrigin.Registry.Server/Exceptions/DatabaseStateException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ProjectOrigin.Registry.Server.Exceptions;
+
+public class DatabaseStateException : Exception
+{
+    public DatabaseStateException(string? message) : base(message)
+    {
+    }
+
+    public DatabaseStateException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/ProjectOrigin.Registry.Server/Exceptions/InvalidConfigurationException.cs
+++ b/src/ProjectOrigin.Registry.Server/Exceptions/InvalidConfigurationException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace ProjectOrigin.Registry.Server.Exceptions;
+
+public class InvalidConfigurationException : Exception
+{
+    public InvalidConfigurationException(string? message) : base(message)
+    {
+    }
+
+    public InvalidConfigurationException(string? message, Exception? innerException) : base(message, innerException)
+    {
+    }
+}

--- a/src/ProjectOrigin.Registry.Server/Extensions/IConfigurationExtensions.cs
+++ b/src/ProjectOrigin.Registry.Server/Extensions/IConfigurationExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
+using ProjectOrigin.Registry.Server.Exceptions;
 using ProjectOrigin.VerifiableEventStore.Services.Repository;
 using Serilog;
 using Serilog.Enrichers.Span;
@@ -78,7 +79,7 @@ public static class IConfigurationExtensions
                 break;
 
             default:
-                throw new ArgumentOutOfRangeException("LogOutputFormat", "Invalid log output format.");
+                throw new InvalidConfigurationException("Invalid log output format.");
         }
 
         return loggerConfiguration.CreateLogger();

--- a/src/ProjectOrigin.Registry.Server/Program.cs
+++ b/src/ProjectOrigin.Registry.Server/Program.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using ProjectOrigin.Registry.Server.Exceptions;
 using ProjectOrigin.Registry.Server.Extensions;
 using ProjectOrigin.VerifiableEventStore.Services.Repository;
 using Serilog;
@@ -33,7 +34,7 @@ try
 
         var upgrader = app.Services.GetRequiredService<IRepositoryUpgrader>();
         if (await upgrader.IsUpgradeRequired())
-            throw new SystemException("Repository is not up to date. Please run with --migrate first.");
+            throw new DatabaseStateException("Repository is not up to date. Please run with --migrate first.");
 
         await app.RunAsync();
         Log.Information("Server stopped.");

--- a/src/ProjectOrigin.Registry.Server/Services/RegistryService.cs
+++ b/src/ProjectOrigin.Registry.Server/Services/RegistryService.cs
@@ -19,9 +19,9 @@ public class RegistryService : V1.RegistryService.RegistryServiceBase
     public static Meter Meter = new("Registry.RegistryService");
     public static Counter<long> TransactionsSubmitted = Meter.CreateCounter<long>("TransactionsSubmitted");
 
-    private ITransactionRepository _transactionRepository;
-    private IBus _bus;
-    private ITransactionStatusService _transactionStatusService;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly IBus _bus;
+    private readonly ITransactionStatusService _transactionStatusService;
 
     public RegistryService(ITransactionRepository eventStore, IBus bus, ITransactionStatusService transactionStatusService)
     {

--- a/src/ProjectOrigin.Registry.Server/Services/TransactionDispatcher.cs
+++ b/src/ProjectOrigin.Registry.Server/Services/TransactionDispatcher.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using Grpc.Net.Client;
 using Microsoft.Extensions.Options;
+using ProjectOrigin.Registry.Server.Exceptions;
 using ProjectOrigin.Registry.Server.Interfaces;
 using ProjectOrigin.Registry.Server.Models;
 using ProjectOrigin.Registry.V1;
@@ -24,7 +25,7 @@ public class TransactionDispatcher : ITransactionDispatcher
 
     public async Task<VerifyTransactionResponse> VerifyTransaction(Transaction transaction, IEnumerable<Transaction> stream)
     {
-        var index = transaction.Header.PayloadType.LastIndexOf(".");
+        var index = transaction.Header.PayloadType.LastIndexOf('.');
         var family = transaction.Header.PayloadType.Substring(0, index);
 
         var client = GetClient(family);
@@ -52,7 +53,7 @@ public class TransactionDispatcher : ITransactionDispatcher
         }
         else
         {
-            throw new Exception($"No verifier found for transaction family {family}");
+            throw new InvalidConfigurationException($"No verifier found for transaction family {family}");
         }
     }
 }

--- a/src/ProjectOrigin.Registry.Server/Services/VerifyTransactionConsumer.cs
+++ b/src/ProjectOrigin.Registry.Server/Services/VerifyTransactionConsumer.cs
@@ -18,11 +18,11 @@ namespace ProjectOrigin.Registry.Server.Services;
 
 public class VerifyTransactionConsumer : IConsumer<VerifyTransaction>
 {
-    private TransactionProcessorOptions _options;
-    private ITransactionRepository _transactionRepository;
-    private ITransactionDispatcher _verifier;
-    private ITransactionStatusService _transactionStatusService;
-    private ILogger<VerifyTransactionConsumer> _logger;
+    private readonly TransactionProcessorOptions _options;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ITransactionDispatcher _verifier;
+    private readonly ITransactionStatusService _transactionStatusService;
+    private readonly ILogger<VerifyTransactionConsumer> _logger;
 
     public VerifyTransactionConsumer(IOptions<TransactionProcessorOptions> options,
                                 ITransactionRepository transactionRepository,
@@ -43,7 +43,7 @@ public class VerifyTransactionConsumer : IConsumer<VerifyTransaction>
         var transactionHash = transaction.GetTransactionHash();
         try
         {
-            _logger.LogDebug($"Processing transaction {transactionHash}");
+            _logger.LogDebug("Processing transaction {transactionHash}", transactionHash);
 
             if (transaction.Header.FederatedStreamId.Registry != _options.RegistryName)
                 throw new InvalidTransactionException("Invalid registry for transaction");
@@ -62,7 +62,7 @@ public class VerifyTransactionConsumer : IConsumer<VerifyTransaction>
             var verifiableEvent = new StreamTransaction { TransactionHash = transactionHash, StreamId = streamId, StreamIndex = nextEventIndex, Payload = transaction.ToByteArray() };
             await _transactionRepository.Store(verifiableEvent).ConfigureAwait(false);
 
-            _logger.LogDebug($"Transaction processed {transactionHash}");
+            _logger.LogDebug("Transaction processed {transactionHash}", transactionHash);
         }
         catch (InvalidTransactionException ex)
         {

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/MerkleTreeTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/MerkleTreeTests.cs
@@ -153,7 +153,7 @@ public class MerkleTreeTests
         Assert.Equal(rootHash, calculatedRoot);
     }
 
-    private byte[] HashRootFromMerkleProof(MerkleProof proof)
+    private static byte[] HashRootFromMerkleProof(MerkleProof proof)
     {
         var balancedTreeNodeCount = (int)Math.Pow(2, proof.Hashes.Count());
         if (proof.LeafIndex >= balancedTreeNodeCount)
@@ -163,7 +163,7 @@ public class MerkleTreeTests
     }
 
 
-    private byte[] HashRootFromMerkleProof(IEnumerable<byte[]> hashes, int leafIndex, byte[] leafContent, int balancedCount)
+    private static byte[] HashRootFromMerkleProof(IEnumerable<byte[]> hashes, int leafIndex, byte[] leafContent, int balancedCount)
     {
         if (!hashes.Any())
         {

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/MerkleTreeTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/MerkleTreeTests.cs
@@ -165,7 +165,7 @@ public class MerkleTreeTests
 
     private byte[] HashRootFromMerkleProof(IEnumerable<byte[]> hashes, int leafIndex, byte[] leafContent, int balancedCount)
     {
-        if (hashes.Count() == 0)
+        if (!hashes.Any())
         {
             var data = SHA256.HashData(leafContent);
             for (int i = (int)Math.Log(balancedCount, 2); i > 0; i--)
@@ -195,12 +195,12 @@ public class MerkleTreeTests
         }
     }
 
-    private byte[] Sha256(byte[] a)
+    private static byte[] Sha256(byte[] a)
     {
         return SHA256.HashData(a);
     }
 
-    private byte[] Sha256(byte[] a, byte[] b)
+    private static byte[] Sha256(byte[] a, byte[] b)
     {
         return SHA256.HashData(a.Concat(b).ToArray());
     }

--- a/src/ProjectOrigin.VerifiableEventStore.Tests/Repository/AbstractTransactionRepositoryTests.cs
+++ b/src/ProjectOrigin.VerifiableEventStore.Tests/Repository/AbstractTransactionRepositoryTests.cs
@@ -77,7 +77,7 @@ public abstract class AbstractTransactionRepositoryTests<T> where T : ITransacti
 
         var events = await Repository.GetStreamTransactionsForStream(streamId);
         Assert.NotEmpty(events);
-        Assert.Equal(NUMBER_OF_EVENTS, events.Count());
+        Assert.Equal(NUMBER_OF_EVENTS, events.Count);
     }
 
     [Fact]
@@ -235,7 +235,7 @@ public abstract class AbstractTransactionRepositoryTests<T> where T : ITransacti
         block1.Should().NotBeNull();
         block1!.Header.PreviousHeaderHash.Should().BeEquivalentTo(new byte[32]);
         block1!.Header.PreviousPublicationHash.Should().BeEquivalentTo(new byte[32]);
-        block1!.TransactionHashes.Should().HaveCount(transactionList1.Count());
+        block1!.TransactionHashes.Should().HaveCount(transactionList1.Count);
         block1!.TransactionHashes.Should().ContainInOrder(transactionList1.Select(x => x.TransactionHash));
         var pub1 = new ImmutableLog.V1.BlockPublication();
         await Repository.FinalizeBlock(BlockHash.FromHeader(block1!.Header), pub1);
@@ -252,7 +252,7 @@ public abstract class AbstractTransactionRepositoryTests<T> where T : ITransacti
         block2.Should().NotBeNull();
         block2!.Header.PreviousHeaderHash.Should().BeEquivalentTo(SHA256.HashData(block1!.Header.ToByteArray()));
         block2!.Header.PreviousPublicationHash.Should().BeEquivalentTo(SHA256.HashData(pub1.ToByteArray()));
-        block2!.TransactionHashes.Should().HaveCount(transactionList2.Count());
+        block2!.TransactionHashes.Should().HaveCount(transactionList2.Count);
         block2!.TransactionHashes.Should().ContainInOrder(transactionList2.Select(x => x.TransactionHash));
         var pub2 = new ImmutableLog.V1.BlockPublication();
         await Repository.FinalizeBlock(BlockHash.FromHeader(block2!.Header), pub2);
@@ -269,7 +269,7 @@ public abstract class AbstractTransactionRepositoryTests<T> where T : ITransacti
         block3.Should().NotBeNull();
         block3!.Header.PreviousHeaderHash.Should().BeEquivalentTo(SHA256.HashData(block2!.Header.ToByteArray()));
         block3!.Header.PreviousPublicationHash.Should().BeEquivalentTo(SHA256.HashData(pub2.ToByteArray()));
-        block3!.TransactionHashes.Should().HaveCount(transactionList3.Count());
+        block3!.TransactionHashes.Should().HaveCount(transactionList3.Count);
         block3!.TransactionHashes.Should().ContainInOrder(transactionList3.Select(x => x.TransactionHash));
         var pub3 = new ImmutableLog.V1.BlockPublication();
         await Repository.FinalizeBlock(BlockHash.FromHeader(block3!.Header), pub3);

--- a/src/ProjectOrigin.VerifiableEventStore/Extensions/IEnumerableMerkleExtension.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Extensions/IEnumerableMerkleExtension.cs
@@ -21,7 +21,7 @@ public static class IEnumerableMerkleExtension
 
     public static IEnumerable<byte[]> GetRequiredHashes<T>(this IList<T> events, Func<T, byte[]> selector, int leafIndex)
     {
-        if (leafIndex > events.Count() - 1)
+        if (leafIndex > events.Count - 1)
         {
             throw new ArgumentException("leafIndex can not be greater than the number of events.", nameof(leafIndex));
         }

--- a/src/ProjectOrigin.VerifiableEventStore/Models/BlockFinalizationOptions.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Models/BlockFinalizationOptions.cs
@@ -5,12 +5,6 @@ namespace ProjectOrigin.VerifiableEventStore.Models;
 
 public class BlockFinalizationOptions
 {
-    private TimeSpan _interval;
-
     [Required, Range(typeof(TimeSpan), "00:00:01", "1:00:00")]
-    public TimeSpan Interval
-    {
-        get => _interval;
-        set => _interval = value;
-    }
+    public TimeSpan Interval { get; set; }
 }

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockFinalizer/BlockFinalizerJob.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockFinalizer/BlockFinalizerJob.cs
@@ -56,9 +56,9 @@ public sealed class BlockFinalizerJob
         }
 
         sw.Stop();
-        _logger.LogInformation("Published new block with {transactionCount} transactions in {elapsedMilliseconds}ms", newBlock.TransactionHashes.Count(), sw.ElapsedMilliseconds);
+        _logger.LogInformation("Published new block with {transactionCount} transactions in {elapsedMilliseconds}ms", newBlock.TransactionHashes.Count, sw.ElapsedMilliseconds);
         BlockCounter.Add(1);
-        TransactionCounter.Add(newBlock.TransactionHashes.Count());
+        TransactionCounter.Add(newBlock.TransactionHashes.Count);
         BlockTime.Record(sw.ElapsedMilliseconds);
     }
 }

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockPublisher/Concordium/ConcordiumPublisher.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockPublisher/Concordium/ConcordiumPublisher.cs
@@ -66,7 +66,6 @@ public class ConcordiumPublisher : IBlockPublisher, IDisposable
                     _logger.LogDebug("Block finalized");
                     return status.Finalized.Outcome;
 
-
                 case ConcordiumV2.BlockItemStatus.StatusOneofCase.Received:
                 case ConcordiumV2.BlockItemStatus.StatusOneofCase.Committed:
                     _logger.LogDebug("Block not yet finalized");
@@ -76,7 +75,7 @@ public class ConcordiumPublisher : IBlockPublisher, IDisposable
                     throw new NotSupportedException("Transaction status is None");
 
                 default:
-                    throw new ArgumentOutOfRangeException();
+                    throw new NotImplementedException($"Transaction status is {status.StatusCase}");
             }
         }
     }
@@ -94,7 +93,7 @@ public class ConcordiumPublisher : IBlockPublisher, IDisposable
         return await _concordiumClient.SendAccountTransactionAsync(signedTransaction);
     }
 
-    private ITransactionSigner GetSigner()
+    private TransactionSigner GetSigner()
     {
         var ed25519TransactionSigner = Ed25519SignKey.From(_options.Value.AccountKey);
         var signer = new TransactionSigner();

--- a/src/ProjectOrigin.VerifiableEventStore/Services/BlockPublisher/Log/LogPublisher.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/BlockPublisher/Log/LogPublisher.cs
@@ -10,7 +10,7 @@ namespace ProjectOrigin.VerifiableEventStore.Services.BlockPublisher.Log;
 /// There is no real immutability guarantee, as the log file is not tamper evident.
 public class LogPublisher : IBlockPublisher
 {
-    private ILogger<LogPublisher> _logger;
+    private readonly ILogger<LogPublisher> _logger;
 
     public LogPublisher(ILogger<LogPublisher> logger)
     {

--- a/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/EventProverService.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/EventProver/EventProverService.cs
@@ -8,7 +8,7 @@ namespace ProjectOrigin.VerifiableEventStore.Services.EventProver;
 
 public class EventProverService : IEventProver
 {
-    private ITransactionRepository _transactionRepository;
+    private readonly ITransactionRepository _transactionRepository;
 
     public EventProverService(ITransactionRepository eventStore)
     {

--- a/src/ProjectOrigin.VerifiableEventStore/Services/Repository/BlockSizeCalculator.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/Repository/BlockSizeCalculator.cs
@@ -2,14 +2,14 @@ using System;
 
 namespace ProjectOrigin.VerifiableEventStore.Services.EventStore;
 
-public class BlockSizeCalculator
+public static class BlockSizeCalculator
 {
     private const int MaxExponent = 20;
 
     /// <summary>
     /// Calculates the block length based on the available number of transactions.
     /// </summary>
-    public long CalculateBlockLength(long availableNumberOfTransactions)
+    public static long CalculateBlockLength(long availableNumberOfTransactions)
     {
         var exponent = Math.Log(availableNumberOfTransactions, 2);
         exponent = Math.Ceiling(exponent);

--- a/src/ProjectOrigin.VerifiableEventStore/Services/Repository/InMemory/InMemoryRepository.cs
+++ b/src/ProjectOrigin.VerifiableEventStore/Services/Repository/InMemory/InMemoryRepository.cs
@@ -13,15 +13,9 @@ namespace ProjectOrigin.VerifiableEventStore.Services.EventStore.InMemory;
 
 public class InMemoryRepository : ITransactionRepository
 {
-    private readonly BlockSizeCalculator _blockSizeCalculator;
     private readonly object _lockObject = new();
     private readonly List<StreamTransaction> _events = new();
     private readonly Dictionary<BlockHash, BlockRecord> _blocks = new();
-
-    public InMemoryRepository()
-    {
-        _blockSizeCalculator = new BlockSizeCalculator();
-    }
 
     public Task<NewBlock?> CreateNextBlock()
     {
@@ -36,7 +30,7 @@ public class InMemoryRepository : ITransactionRepository
             if (_events.Count <= fromTransaction)
                 return Task.FromResult<NewBlock?>(null);
 
-            var numberOfTransactions = (int)_blockSizeCalculator.CalculateBlockLength(_events.Count - fromTransaction);
+            var numberOfTransactions = (int)BlockSizeCalculator.CalculateBlockLength(_events.Count - fromTransaction);
 
             var transactions = _events.Skip(fromTransaction).Take(numberOfTransactions).ToList();
 
@@ -158,5 +152,5 @@ public class InMemoryRepository : ITransactionRepository
     }
 
 
-    private record BlockRecord(ImmutableLog.V1.BlockHeader Header, ImmutableLog.V1.BlockPublication? Publication, int FromTransaction, int ToTransaction);
+    private sealed record BlockRecord(ImmutableLog.V1.BlockHeader Header, ImmutableLog.V1.BlockPublication? Publication, int FromTransaction, int ToTransaction);
 }


### PR DESCRIPTION
This pull request fixes several code smells identified by SonarCloud. The changes include:

- Making the `_transactionRepository` field in the `EventProverService` class `readonly`.

- Adding the `DatabaseStateException` exception class to the `ProjectOrigin.Registry.Server.Exceptions` namespace.

- Adding the `InvalidConfigurationException` exception class to the `ProjectOrigin.Registry.Server.Exceptions` and `ProjectOrigin.Electricity.Server.Exceptions` namespaces.

- Making the `_logger` field in the `LogPublisher` class `readonly`.

- Adding a null reference check in the `HydrateModel` method of the `AbstractModelHydrator` class.

- Adding a null reference check in the `GetChannel` method of the `RegistryClientFactory` class.

- Adding a `KeyNotFoundException` when a registry is not known in the `GetChannel` method of the `RegistryClientFactory` class.

- Adding a null reference check in the `CreateInvalidSignedEvent` method of the `TransactionVerifierTests` class.

- Fixing the `GetRequiredHashes` method in the `MerkleTreeExtensions` class to throw an `ArgumentException` when the `leafIndex` is greater than the number of events.

- Adding a null reference check in the `SignEvent` method of the `TransactionVerifier` class.

- Adding a null reference check in the `Verify` method of the `GranularCertificateVerifier` class.

- Adding the `InvalidConfigurationException` exception class to the `ProjectOrigin.Electricity.Server.Exceptions` namespace.

- Adding a null reference check in the `GetSeriLogger` extension method of the `IConfiguration` class.

- Adding the `InvalidConfigurationException` exception class to the `ProjectOrigin.Registry.Server.Exceptions` namespace.