### PR TITLE
Removed ProjectOrigin.Electricty project

### DIFF
--- a/src/ProjectOrigin.Electricity.Server/Interfaces/IEventVerifier.cs
+++ b/src/ProjectOrigin.Electricity.Server/Interfaces/IEventVerifier.cs
@@ -1,5 +1,5 @@
 using System.Threading.Tasks;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 
 namespace ProjectOrigin.Electricity.Server.Interfaces;
 

--- a/src/ProjectOrigin.Electricity.Server/Models/CertificateSlices.cs
+++ b/src/ProjectOrigin.Electricity.Server/Models/CertificateSlices.cs
@@ -1,4 +1,4 @@
-namespace ProjectOrigin.Electricity.Models;
+namespace ProjectOrigin.Electricity.Server.Models;
 
 public record AllocationSlice(
     Electricity.V1.Commitment Commitment,

--- a/src/ProjectOrigin.Electricity.Server/Models/GranularCertificate.cs
+++ b/src/ProjectOrigin.Electricity.Server/Models/GranularCertificate.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Security.Cryptography;
 using Google.Protobuf;
 
-namespace ProjectOrigin.Electricity.Models;
+namespace ProjectOrigin.Electricity.Server.Models;
 
 public class GranularCertificate
 {

--- a/src/ProjectOrigin.Electricity.Server/ProjectOrigin.Electricity.Server.csproj
+++ b/src/ProjectOrigin.Electricity.Server/ProjectOrigin.Electricity.Server.csproj
@@ -1,7 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <ItemGroup>
-    <ProjectReference Include="..\ProjectOrigin.Electricity\ProjectOrigin.Electricity.csproj" />
     <PackageReference Include="ProjectOrigin.PedersenCommitment" Version="1.0.3" />
     <PackageReference Include="ProjectOrigin.HierarchicalDeterministicKeys" Version="0.4.0" />
     <PackageReference Include="Grpc.AspNetCore" Version="2.59.0" />
@@ -13,6 +12,8 @@
   <ItemGroup>
     <Protobuf Include="..\Protos\verifier.proto" GrpcServices="Server" Access="Internal" />
     <Protobuf Include="..\Protos\registry.proto" GrpcServices="Client" Access="Public" />
+    <Protobuf Include="..\Protos\electricity.proto" GrpcServices="None" />
+    <Protobuf Include="..\Protos\common.proto" GrpcServices="None" />
   </ItemGroup>
 
 </Project>

--- a/src/ProjectOrigin.Electricity.Server/Services/ElectricityModelHydrater.cs
+++ b/src/ProjectOrigin.Electricity.Server/Services/ElectricityModelHydrater.cs
@@ -1,5 +1,5 @@
 using System;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 
 namespace ProjectOrigin.Electricity.Server.Services;
 

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Allocated.cs
@@ -2,7 +2,7 @@ using ProjectOrigin.Electricity.Extensions;
 using ProjectOrigin.PedersenCommitment;
 using ProjectOrigin.Registry.V1;
 using System.Threading.Tasks;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using System;
 using ProjectOrigin.Electricity.Server.Interfaces;
 

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Claimed.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Claimed.cs
@@ -3,7 +3,7 @@ using ProjectOrigin.Electricity.V1;
 using ProjectOrigin.Registry.V1;
 using System.Threading.Tasks;
 using System;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 
 namespace ProjectOrigin.Electricity.Server.Verifiers;

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Issued.cs
@@ -1,7 +1,7 @@
 using ProjectOrigin.Electricity.Extensions;
 using ProjectOrigin.Registry.V1;
 using System.Threading.Tasks;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 
 namespace ProjectOrigin.Electricity.Server.Verifiers;

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Sliced.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Sliced.cs
@@ -3,7 +3,7 @@ using ProjectOrigin.PedersenCommitment;
 using ProjectOrigin.Registry.V1;
 using System.Threading.Tasks;
 using System.Linq;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 
 namespace ProjectOrigin.Electricity.Server.Verifiers;

--- a/src/ProjectOrigin.Electricity.Server/Verifiers/Transferred.cs
+++ b/src/ProjectOrigin.Electricity.Server/Verifiers/Transferred.cs
@@ -1,7 +1,7 @@
 using ProjectOrigin.Electricity.Extensions;
 using ProjectOrigin.Registry.V1;
 using System.Threading.Tasks;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 
 namespace ProjectOrigin.Electricity.Server.Verifiers;

--- a/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionAllocatedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionAllocatedVerifierTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 using ProjectOrigin.Electricity.Server.Verifiers;
 using ProjectOrigin.HierarchicalDeterministicKeys;

--- a/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionCertificateApplyTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionCertificateApplyTests.cs
@@ -1,7 +1,7 @@
 using System.Security.Cryptography;
 using Google.Protobuf;
 using ProjectOrigin.Electricity.Extensions;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.PedersenCommitment;
 using Xunit;
 using System;

--- a/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionClaimedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionClaimedVerifierTests.cs
@@ -1,6 +1,6 @@
 using System.Threading.Tasks;
 using Moq;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 using ProjectOrigin.Electricity.Server.Verifiers;
 using ProjectOrigin.HierarchicalDeterministicKeys;

--- a/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionIssuedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Consumption/ConsumptionIssuedVerifierTests.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 using AutoFixture;
 using Microsoft.Extensions.Options;
 using Moq;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Options;
 using ProjectOrigin.Electricity.Server.Services;
 using ProjectOrigin.Electricity.Server.Verifiers;

--- a/src/ProjectOrigin.Electricity.Tests/FakeRegister.cs
+++ b/src/ProjectOrigin.Electricity.Tests/FakeRegister.cs
@@ -4,7 +4,7 @@ using AutoFixture;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using NSec.Cryptography;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.HierarchicalDeterministicKeys;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
 using ProjectOrigin.PedersenCommitment;

--- a/src/ProjectOrigin.Electricity.Tests/ModelHydraterTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/ModelHydraterTests.cs
@@ -4,7 +4,7 @@ using System.Security.Cryptography;
 using AutoFixture;
 using FluentAssertions;
 using Google.Protobuf;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Services;
 using Xunit;
 

--- a/src/ProjectOrigin.Electricity.Tests/Production/ProductionAllocatedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Production/ProductionAllocatedVerifierTests.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using AutoFixture;
 using Moq;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 using ProjectOrigin.Electricity.Server.Verifiers;
 using ProjectOrigin.HierarchicalDeterministicKeys;

--- a/src/ProjectOrigin.Electricity.Tests/Production/ProductionCertificateApplyTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Production/ProductionCertificateApplyTests.cs
@@ -4,9 +4,7 @@ using AutoFixture;
 using Google.Protobuf;
 using Google.Protobuf.WellKnownTypes;
 using ProjectOrigin.Electricity.Extensions;
-using ProjectOrigin.Electricity.Models;
-using ProjectOrigin.Electricity.Server.Verifiers;
-
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.HierarchicalDeterministicKeys;
 using ProjectOrigin.PedersenCommitment;
 using Xunit;

--- a/src/ProjectOrigin.Electricity.Tests/Production/ProductionClaimedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Production/ProductionClaimedVerifierTests.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Moq;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Interfaces;
 using ProjectOrigin.Electricity.Server.Verifiers;
 using ProjectOrigin.HierarchicalDeterministicKeys;

--- a/src/ProjectOrigin.Electricity.Tests/Production/ProductionIssuedVerifierTests.cs
+++ b/src/ProjectOrigin.Electricity.Tests/Production/ProductionIssuedVerifierTests.cs
@@ -6,13 +6,12 @@ using AutoFixture;
 using Microsoft.Extensions.Options;
 using Moq;
 using ProjectOrigin.Electricity.Extensions;
-using ProjectOrigin.Electricity.Models;
+using ProjectOrigin.Electricity.Server.Models;
 using ProjectOrigin.Electricity.Server.Options;
 using ProjectOrigin.Electricity.Server.Services;
 using ProjectOrigin.Electricity.Server.Verifiers;
 using ProjectOrigin.HierarchicalDeterministicKeys;
 using ProjectOrigin.HierarchicalDeterministicKeys.Interfaces;
-using ProjectOrigin.PedersenCommitment;
 using Xunit;
 
 namespace ProjectOrigin.Electricity.Tests;

--- a/src/Registry.sln
+++ b/src/Registry.sln
@@ -12,8 +12,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.Registry.Serv
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.Registry.IntegrationTests", "ProjectOrigin.Registry.IntegrationTests\ProjectOrigin.Registry.IntegrationTests.csproj", "{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.Electricity", "ProjectOrigin.Electricity\ProjectOrigin.Electricity.csproj", "{D7DE4F91-544E-428A-860F-339DE1D7307D}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.Electricity.Server", "ProjectOrigin.Electricity.Server\ProjectOrigin.Electricity.Server.csproj", "{401E3E53-9CA1-46B5-BEA4-DCBE662ADF7C}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ProjectOrigin.Electricity.Tests", "ProjectOrigin.Electricity.Tests\ProjectOrigin.Electricity.Tests.csproj", "{4910B564-4DCF-4AC4-AA5B-4A404A905962}"
@@ -53,10 +51,6 @@ Global
 		{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0C7EF78A-5D77-4B04-BDC4-EBE2C5F179AA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D7DE4F91-544E-428A-860F-339DE1D7307D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D7DE4F91-544E-428A-860F-339DE1D7307D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D7DE4F91-544E-428A-860F-339DE1D7307D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D7DE4F91-544E-428A-860F-339DE1D7307D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{401E3E53-9CA1-46B5-BEA4-DCBE662ADF7C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{401E3E53-9CA1-46B5-BEA4-DCBE662ADF7C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{401E3E53-9CA1-46B5-BEA4-DCBE662ADF7C}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
This moves two c# models from otherwise empty Project, this was done to simplify the code.