### PR TITLE
Update TransactionProcessorOptions to use PodName instead of ServerNumber

### DIFF
--- a/charts/project-origin-registry/templates/registry-deployment.yaml
+++ b/charts/project-origin-registry/templates/registry-deployment.yaml
@@ -36,10 +36,14 @@ spec:
               value: {{ .Values.registryName | default .Release.Name }}
 
           # TransactionProcessor configuration
-            - name: TransactionProcessor__ServerNumber
+            - name: TransactionProcessor__PodName
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
+                  fieldPath: metadata.name
+            # - name: TransactionProcessor__ServerNumber
+            #   valueFrom:
+            #     fieldRef:
+            #       fieldPath: metadata.labels['apps.kubernetes.io/pod-index']
             - name: TransactionProcessor__Servers
               value: {{ .Values.transactionProcessor.replicas | quote }}
             - name: TransactionProcessor__Threads

--- a/src/ProjectOrigin.Registry.Server/Options/TransactionProcessorOptions.cs
+++ b/src/ProjectOrigin.Registry.Server/Options/TransactionProcessorOptions.cs
@@ -23,7 +23,7 @@ public record TransactionProcessorOptions()
     }
 
     [Required, Range(0, 127)]
-    public required int ServerNumber { get; init; }
+    public required int ServerNumber { get; init; } = -1;
 
     [Required, Range(1, 128)]
     public required int Servers { get; init; }

--- a/src/ProjectOrigin.Registry.Server/Options/TransactionProcessorOptions.cs
+++ b/src/ProjectOrigin.Registry.Server/Options/TransactionProcessorOptions.cs
@@ -1,9 +1,27 @@
 using System.ComponentModel.DataAnnotations;
+using System.Text.RegularExpressions;
 
 namespace ProjectOrigin.Registry.Server.Options;
 
 public record TransactionProcessorOptions()
 {
+    // To compensate for pre 1.28 kubernetes that does not support apps.kubernetes.io/pod-index
+    public string? PodName
+    {
+        init
+        {
+            // regex to find last integer in a string
+            if (value is not null)
+            {
+                var match = Regex.Match(value, @"\d+$");
+                if (match.Success)
+                {
+                    ServerNumber = int.Parse(match.Value);
+                }
+            }
+        }
+    }
+
     [Required, Range(0, 127)]
     public required int ServerNumber { get; init; }
 


### PR DESCRIPTION
This pull request updates the TransactionProcessorOptions class to use the PodName property instead of the ServerNumber property. It also sets the default value of the ServerNumber property to -1 if it is not set. This change ensures compatibility with pre-1.28 versions of Kubernetes that do not support the apps.kubernetes.io/pod-index label.