### PR TITLE
Update port numbers for concordium-node and concordium-service

### DIFF
--- a/charts/project-origin-registry/templates/concordium-node.yaml
+++ b/charts/project-origin-registry/templates/concordium-node.yaml
@@ -24,7 +24,7 @@ spec:
           image: concordium/{{ required  "A concordium.network must be specificed ( testnet | mainnet )" .Values.concordium.network }}-node:6.3.0-0
           command: ["/concordium-node"]
           ports:
-            - containerPort: 10000
+            - containerPort: 20000
           env:
             # Environment specific configuration
             # The url where IPs of the bootstrap nodes can be found.

--- a/charts/project-origin-registry/templates/concordium-service.yaml
+++ b/charts/project-origin-registry/templates/concordium-service.yaml
@@ -10,6 +10,6 @@ spec:
   ports:
     - name: grpc
       protocol: TCP
-      port: 10000
-      targetPort: 10000
+      port: 20000
+      targetPort: 20000
 {{- end }}

--- a/charts/project-origin-registry/values.yaml
+++ b/charts/project-origin-registry/values.yaml
@@ -113,7 +113,7 @@ immutableRecord:
   # concordium holds the configuration to contact and publish data on the network
   concordium:
     # rpcUrl are the url on which the local node is available.
-    rpcUrl: http://po-concordium:10000
+    rpcUrl: http://po-concordium:20000
     # rpcToken is the token used to communicate with the node.
     rpcToken: rpcadmin
     # accountAddress must hold the address from which to use CCD


### PR DESCRIPTION
This pull request updates the port numbers for concordium-node and concordium-service to 20000. 