### PR TITLE
Bug - multiple finalizers running

### DIFF
--- a/src/ProjectOrigin.Registry.Server/Extensions/IConfigurationExtensions.cs
+++ b/src/ProjectOrigin.Registry.Server/Extensions/IConfigurationExtensions.cs
@@ -14,7 +14,7 @@ namespace ProjectOrigin.Registry.Server.Extensions;
 
 public static class IConfigurationExtensions
 {
-    public static T GetValid<T>(this IConfiguration configuration) where T : IValidatableObject
+    public static T GetValid<T>(this IConfiguration configuration)
     {
         try
         {

--- a/src/ProjectOrigin.Registry.Server/Startup.cs
+++ b/src/ProjectOrigin.Registry.Server/Startup.cs
@@ -107,8 +107,8 @@ public class Startup
         services.AddHostedService<QueueCleanupService>();
 
         // Only one server should run the block finalizer
-        var serverNumber = _configuration.GetSection("TransactionProcessor").GetValue<int>("ServerNumber");
-        if (serverNumber == 0)
+        var processorOptions = _configuration.GetRequiredSection("TransactionProcessor").GetValid<TransactionProcessorOptions>();
+        if (processorOptions.ServerNumber == 0)
         {
             services.AddHostedService<BlockFinalizerBackgroundService>();
             services.AddTransient<IBlockFinalizer, BlockFinalizerJob>();


### PR DESCRIPTION
When using the statefulset name, there was a error in the way the value was retrieved in the startup configuration. 
This has now been fixed.