### PR TITLE
Add required `serviceName`

### DIFF
--- a/charts/project-origin-registry/templates/registry-deployment.yaml
+++ b/charts/project-origin-registry/templates/registry-deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     app: registry-{{ .Release.Name }}
 spec:
+  serviceName: registry-{{ .Release.Name }}
   replicas: {{ .Values.transactionProcessor.replicas }}
   selector:
     matchLabels:

--- a/charts/project-origin-registry/templates/registry-deployment.yaml
+++ b/charts/project-origin-registry/templates/registry-deployment.yaml
@@ -5,7 +5,7 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: registry-{{ .Release.Name }}-processor
+  name: registry-{{ .Release.Name }}-processors
   labels:
     app: registry-{{ .Release.Name }}
 spec:


### PR DESCRIPTION
I am trying to validate kubernetes manifests with kubeconform before applying them.

 The schema for a StatefulSet requires the `serviceName` to be set.

 The schemas used during validation are from https://github.com/yannh/kubernetes-json-schema which in turn takes the schemas directly from https://github.com/kubernetes/kubernetes.

There is a long discussion about using StatefulSet without `serviceName` here: https://github.com/kubernetes/kubernetes/issues/69608
