### PR TITLE
Add "helm.sh/resource-policy" annotations to cnpg-cluster.yaml and rabbitmq.yaml

### DIFF
--- a/charts/project-origin-registry/templates/cnpg-cluster.yaml
+++ b/charts/project-origin-registry/templates/cnpg-cluster.yaml
@@ -5,6 +5,8 @@ kind: Cluster
 metadata:
   name: {{ .Values.persistance.cloudNativePG.name }}
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
 spec:
   instances: {{ .Values.persistance.cloudNativePG.replicas }}
   storage:

--- a/charts/project-origin-registry/templates/rabbitmq.yaml
+++ b/charts/project-origin-registry/templates/rabbitmq.yaml
@@ -4,4 +4,6 @@ kind: RabbitmqCluster
 metadata:
   name: {{ .Release.Name }}-rabbitmq
   namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/resource-policy": keep
 {{- end }}


### PR DESCRIPTION
This pull request adds the "helm.sh/resource-policy" annotations to the `cnpg-cluster.yaml` and `rabbitmq.yaml` files. These annotations ensure that the resources defined in these files are not deleted during a Helm upgrade.