### PR TITLE
Update ephemeral-storage limit in deployment.yaml

### DIFF
--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
               cpu: 0.1
             limits:
               memory: 50Mi
-              ephemeral-storage: "1Mi"
+              ephemeral-storage: "100Mi"
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
This pull request updates the `ephemeral-storage` limit in the `deployment.yaml` file. The limit is increased from "1Mi" to "100Mi". Keeps rebooting