### PR TITLE
 Added finalized state

### DIFF
--- a/Registry.Dockerfile
+++ b/Registry.Dockerfile
@@ -22,4 +22,6 @@ COPY --from=build /app/publish .
 EXPOSE 5000
 EXPOSE 5001
 
+ENV ReturnComittedForFinalized=true
+
 ENTRYPOINT ["dotnet", "App.dll"]

--- a/chart/templates/deployment.yaml
+++ b/chart/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
           # General configuration
             - name: RegistryName
               value: {{ $.Values.registryName | default $.Release.Name }}
+            - name: ReturnComittedForFinalized
+              value: {{ $.Values.returnComittedForFinalized | quote }}
 
           # TransactionProcessor configuration
             - name: TransactionProcessor__ServerNumber

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -47,6 +47,9 @@ otlp:
 # Enables one to override the name of the registry
 registryName:
 
+# The registry returns comitted for finalized transactions to enable backwards compatibility with older clients
+returnComittedForFinalized: true
+
 # transactionProcessor holds the configuration for the transaction processor
 transactionProcessor:
   # replicas defines the number of transaction processor containers to run

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "8.0.402",
+        "version": "8.0.401",
         "rollForward": "feature"
     }
 }

--- a/protos/registry.proto
+++ b/protos/registry.proto
@@ -74,6 +74,7 @@ enum TransactionState {
     PENDING = 1;
     FAILED = 2;
     COMMITTED = 3;
+    FINALIZED = 4;
 }
 
 message GetTransactionProofRequest {

--- a/src/ProjectOrigin.Registry/BlockFinalizer/Process/BlockFinalizerJob.cs
+++ b/src/ProjectOrigin.Registry/BlockFinalizer/Process/BlockFinalizerJob.cs
@@ -50,7 +50,7 @@ public sealed class BlockFinalizerJob : IBlockFinalizer
 
         foreach (var transactionHash in newBlock.TransactionHashes)
         {
-            await _statusService.SetTransactionStatus(transactionHash, new TransactionStatusRecord(TransactionStatus.Committed));
+            await _statusService.SetTransactionStatus(transactionHash, new TransactionStatusRecord(TransactionStatus.Finalized));
         }
 
         sw.Stop();

--- a/src/ProjectOrigin.Registry/Options/RegistryOptions.cs
+++ b/src/ProjectOrigin.Registry/Options/RegistryOptions.cs
@@ -7,5 +7,5 @@ public record RegistryOptions()
     [Required(AllowEmptyStrings = false)]
     public string RegistryName { get; init; } = string.Empty;
 
-    public bool ReturnComittedForFinalized = false;
+    public bool ReturnComittedForFinalized { get; init; } = false;
 }

--- a/src/ProjectOrigin.Registry/Options/RegistryOptions.cs
+++ b/src/ProjectOrigin.Registry/Options/RegistryOptions.cs
@@ -6,4 +6,6 @@ public record RegistryOptions()
 {
     [Required(AllowEmptyStrings = false)]
     public string RegistryName { get; init; } = string.Empty;
+
+    public bool ReturnComittedForFinalized = false;
 }

--- a/src/ProjectOrigin.Registry/Repository/InMemory/InMemoryRepository.cs
+++ b/src/ProjectOrigin.Registry/Repository/InMemory/InMemoryRepository.cs
@@ -166,9 +166,9 @@ public class InMemoryRepository : ITransactionRepository
             var block = _blocks.SingleOrDefault(x => x.FromTransaction <= index && index <= x.ToTransaction);
 
             if (block is not null && block.Publication is not null)
-                return Task.FromResult(TransactionStatus.Committed);
+                return Task.FromResult(TransactionStatus.Finalized);
 
-            return Task.FromResult(TransactionStatus.Pending);
+            return Task.FromResult(TransactionStatus.Committed);
         }
     }
 

--- a/src/ProjectOrigin.Registry/Repository/Models/TransactionStatus.cs
+++ b/src/ProjectOrigin.Registry/Repository/Models/TransactionStatus.cs
@@ -5,5 +5,6 @@ public enum TransactionStatus
     Unknown = 0,
     Pending = 1,
     Failed = 2,
-    Committed = 3
+    Committed = 3,
+    Finalized = 4
 }

--- a/src/ProjectOrigin.Registry/Repository/Postgres/PostgresqlRepository.cs
+++ b/src/ProjectOrigin.Registry/Repository/Postgres/PostgresqlRepository.cs
@@ -120,9 +120,9 @@ public sealed class PostgresqlRepository : ITransactionRepository, IDisposable
             new { id });
 
         if (hasBeenPublished.HasValue && hasBeenPublished.Value)
-            return TransactionStatus.Committed;
+            return TransactionStatus.Finalized;
 
-        return TransactionStatus.Pending;
+        return TransactionStatus.Committed;
     }
 
     public async Task<NewBlock?> CreateNextBlock()

--- a/src/ProjectOrigin.Registry/TransactionProcessor/TransactionProcessorDispatcher.cs
+++ b/src/ProjectOrigin.Registry/TransactionProcessor/TransactionProcessorDispatcher.cs
@@ -57,6 +57,7 @@ public class TransactionProcessorDispatcher
             var nextEventIndex = stream.Count;
             var verifiableEvent = new StreamTransaction { TransactionHash = transactionHash, StreamId = streamId, StreamIndex = nextEventIndex, Payload = transaction.ToByteArray() };
             await _transactionRepository.Store(verifiableEvent).ConfigureAwait(false);
+            await _transactionStatusService.SetTransactionStatus(transactionHash, new TransactionStatusRecord(TransactionStatus.Committed));
 
             _logger.LogDebug("Transaction processed {transactionHash}", transactionHash);
         }

--- a/test/ProjectOrigin.Registry.ChartTests/Extensions/RegistryServiceClientExtensions.cs
+++ b/test/ProjectOrigin.Registry.ChartTests/Extensions/RegistryServiceClientExtensions.cs
@@ -33,7 +33,7 @@ public static class RegistryServiceClientExtensions
         {
             var result = await getTransactionStatus();
 
-            if (result.Status == TransactionState.Committed)
+            if (result.Status == TransactionState.Committed || result.Status == TransactionState.Finalized)
                 return result;
             else if (result.Status == TransactionState.Failed)
                 Assert.Fail($"Transaction failed ”{result.Status}” with message ”{result.Message}”");

--- a/test/ProjectOrigin.Registry.IntegrationTests/ContainerTest.cs
+++ b/test/ProjectOrigin.Registry.IntegrationTests/ContainerTest.cs
@@ -64,6 +64,7 @@ public class ContainerTest : IAsyncLifetime,
                 .WithPortBinding(GrpcPort, true)
                 .WithCommand("--serve")
                 .WithEnvironment("RegistryName", RegistryName)
+                .WithEnvironment("ReturnComittedForFinalized", "false")
                 .WithEnvironment("Verifiers__project_origin.electricity.v1", verifierUrl)
                 .WithEnvironment("ImmutableLog__type", "log")
                 .WithEnvironment("BlockFinalizer__Interval", "00:00:05")
@@ -147,7 +148,7 @@ public class ContainerTest : IAsyncLifetime,
 
         status = await Helper.RepeatUntilOrTimeout(
             () => Client.GetStatus(transaction),
-            result => result.Status == Registry.V1.TransactionState.Committed,
+            result => result.Status == Registry.V1.TransactionState.Finalized,
             TimeSpan.FromSeconds(60));
 
         status.Message.Should().BeEmpty();

--- a/test/ProjectOrigin.Registry.IntegrationTests/FlowTestsComitted.cs
+++ b/test/ProjectOrigin.Registry.IntegrationTests/FlowTestsComitted.cs
@@ -13,7 +13,7 @@ using ProjectOrigin.Registry.IntegrationTests.Fixtures;
 
 namespace ProjectOrigin.Electricity.IntegrationTests;
 
-public class FlowTests :
+public class FlowTestsComitted :
     IClassFixture<TestServerFixture<Startup>>,
     IClassFixture<ElectricityServiceFixture>,
     IClassFixture<PostgresDatabaseFixture<Startup>>,
@@ -27,7 +27,7 @@ public class FlowTests :
     private readonly Lazy<Registry.V1.RegistryService.RegistryServiceClient> _client;
     protected Registry.V1.RegistryService.RegistryServiceClient Client => _client.Value;
 
-    public FlowTests(
+    public FlowTestsComitted(
         ElectricityServiceFixture verifierFixture,
         TestServerFixture<Startup> serverFixture,
         PostgresDatabaseFixture<Startup> postgresDatabaseFixture,
@@ -42,6 +42,7 @@ public class FlowTests :
         {
             {"Otlp:Enabled", "false"},
             {"RegistryName", RegistryName},
+            {"ReturnComittedForFinalized", "true"},
             {"Verifiers:project_origin.electricity.v1", _verifierFixture.Url},
             {"ImmutableLog:type", "log"},
             {"BlockFinalizer:Interval", "00:00:05"},
@@ -90,11 +91,13 @@ public class FlowTests :
         var stream = await Client.GetStream(certId);
         stream.Transactions.Should().HaveCount(1);
 
+        await Task.Delay(10000);
+
         var blocks = await Client.GetBlocksAsync(new Registry.V1.GetBlocksRequest
         {
             Skip = 0,
             Limit = 1,
-            IncludeTransactions = true
+            IncludeTransactions = false
         });
 
         blocks.Blocks.Should().HaveCount(1);

--- a/test/ProjectOrigin.Registry.IntegrationTests/FlowTestsComitted.cs
+++ b/test/ProjectOrigin.Registry.IntegrationTests/FlowTestsComitted.cs
@@ -83,7 +83,7 @@ public class FlowTestsComitted :
 
         status = await Helper.RepeatUntilOrTimeout(
             () => Client.GetStatus(transaction),
-            result => result.Status == Registry.V1.TransactionState.Finalized,
+            result => result.Status == Registry.V1.TransactionState.Committed,
             TimeSpan.FromSeconds(60));
 
         status.Message.Should().BeEmpty();

--- a/test/ProjectOrigin.Registry.IntegrationTests/Helper.cs
+++ b/test/ProjectOrigin.Registry.IntegrationTests/Helper.cs
@@ -86,6 +86,16 @@ public static class Helper
         });
     }
 
+    public static async Task<Registry.V1.GetBlocksResponse> GetBlock(this Registry.V1.RegistryService.RegistryServiceClient client)
+    {
+        return await client.GetBlocksAsync(new Registry.V1.GetBlocksRequest
+        {
+            Skip = 0,
+            Limit = 1,
+            IncludeTransactions = false
+        });
+    }
+
     public static Registry.V1.Transaction SignTransaction(Common.V1.FederatedStreamId streamId, IMessage @event, IPrivateKey signerKey)
     {
         var header = new Registry.V1.TransactionHeader()

--- a/test/ProjectOrigin.Registry.IntegrationTests/PerformanceTests.cs
+++ b/test/ProjectOrigin.Registry.IntegrationTests/PerformanceTests.cs
@@ -128,7 +128,7 @@ public class PerformanceTests : IAsyncLifetime,
                     {
                         if (queued.TryDequeue(out var transaction))
                         {
-                            if (await IsCommitted(channel, transaction))
+                            if (await IsFinalized(channel, transaction))
                             {
                                 completed.Add(transaction);
                             }
@@ -170,7 +170,7 @@ public class PerformanceTests : IAsyncLifetime,
         {
             stopwatch.Restart();
             var transaction = await SendRequest(channel);
-            while (!await IsCommitted(channel, transaction))
+            while (!await IsFinalized(channel, transaction))
             {
                 await Task.Delay(25);
             }
@@ -213,7 +213,7 @@ public class PerformanceTests : IAsyncLifetime,
 
         while (queued.TryDequeue(out var item))
         {
-            if (await IsCommitted(channel, item.transaction))
+            if (await IsFinalized(channel, item.transaction))
             {
                 item.stopwatch.Stop();
                 measurements.Add(item.stopwatch.ElapsedMilliseconds);
@@ -279,11 +279,11 @@ public class PerformanceTests : IAsyncLifetime,
         _outputHelper.WriteLine($"-------Container stdout------\n{log.Stdout}\n-------Container stderr------\n{log.Stderr}\n\n----------");
     }
 
-    private static async Task<bool> IsCommitted(GrpcChannel channel, Registry.V1.Transaction transaction)
+    private static async Task<bool> IsFinalized(GrpcChannel channel, Registry.V1.Transaction transaction)
     {
         var client = new Registry.V1.RegistryService.RegistryServiceClient(channel);
         var result = await client.GetStatus(transaction);
-        return result.Status == Registry.V1.TransactionState.Committed;
+        return result.Status == Registry.V1.TransactionState.Finalized;
     }
 
 }

--- a/test/ProjectOrigin.Registry.Tests/BlockFinalizerJobTests.cs
+++ b/test/ProjectOrigin.Registry.Tests/BlockFinalizerJobTests.cs
@@ -68,7 +68,7 @@ public class BlockFinalizerJobTests
         _repository.Verify(obj => obj.CreateNextBlock(), Times.Exactly(1));
         _blockPublisher.Verify(obj => obj.PublishBlock(It.Is<Registry.V1.BlockHeader>(x => x == header)), Times.Exactly(1));
         _repository.Verify(obj => obj.FinalizeBlock(It.Is<BlockHash>(x => x.Equals(BlockHash.FromHeader(header))), It.Is<Registry.V1.BlockPublication>(x => x == publication)), Times.Exactly(1));
-        _statusService.Verify(obj => obj.SetTransactionStatus(It.IsAny<TransactionHash>(), It.Is<TransactionStatusRecord>(x => x.NewStatus == TransactionStatus.Committed)), Times.Exactly(transactions.Count));
+        _statusService.Verify(obj => obj.SetTransactionStatus(It.IsAny<TransactionHash>(), It.Is<TransactionStatusRecord>(x => x.NewStatus == TransactionStatus.Finalized)), Times.Exactly(transactions.Count));
     }
 
     [Fact]

--- a/test/ProjectOrigin.Registry.Tests/TransactionStatusCache/AbstractTransactionStatusServiceTests.cs
+++ b/test/ProjectOrigin.Registry.Tests/TransactionStatusCache/AbstractTransactionStatusServiceTests.cs
@@ -68,7 +68,7 @@ public abstract class AbstractTransactionStatusServiceTests
     }
 
     [Fact]
-    public async Task ShouldReturnPendingRecordFromRepositoryNotInBlock()
+    public async Task ShouldReturnCommittedRecordFromRepositoryNotInBlock()
     {
         // Arrange
         var data = _fixture.Create<byte[]>();
@@ -85,11 +85,11 @@ public abstract class AbstractTransactionStatusServiceTests
         var record = await Service.GetTransactionStatus(transactionHash);
 
         // Assert
-        record.NewStatus.Should().Be(TransactionStatus.Pending);
+        record.NewStatus.Should().Be(TransactionStatus.Committed);
     }
 
     [Fact]
-    public async Task ShouldReturnCommittedRecordFromRepositoryInBlock()
+    public async Task ShouldReturnFinalizedRecordFromRepositoryInBlock()
     {
         // Arrange
         var data = _fixture.Create<byte[]>();
@@ -109,6 +109,6 @@ public abstract class AbstractTransactionStatusServiceTests
         var record = await Service.GetTransactionStatus(transactionHash);
 
         // Assert
-        record.NewStatus.Should().Be(TransactionStatus.Committed);
+        record.NewStatus.Should().Be(TransactionStatus.Finalized);
     }
 }


### PR DESCRIPTION
Added new state for transactions in the registry - Finalized, this is a new state that denotes that a transaction is published to the immutable log. It replaces the previous comitted state, which gains a new meaning, now when a transaction is comitted, the registry has verified the transaction, and is comitted to publishing it, but has not yet done this. This enables clients to continue to do multiple transactions on the same stream without waiting for the next block.

The chart now has a returnComittedForFinalized setting the for now defaults to true, this ensures that all clients currently will still work with registry. If set to false, the registry will return this new state, and old clients will throw an error. This is for compatibility in a transition period.