### PR TITLE
Fix redis status service transaction handling

### DIFF
--- a/src/ProjectOrigin.Registry/TransactionStatusCache/RedisTransactionStatusService.cs
+++ b/src/ProjectOrigin.Registry/TransactionStatusCache/RedisTransactionStatusService.cs
@@ -75,7 +75,7 @@ public class RedisTransactionStatusService : ITransactionStatusService
         {
             var transaction = redisDatabase.CreateTransaction();
             transaction.AddCondition(Condition.StringEqual(transactionHash, JsonSerializer.Serialize(cacheRecord)));
-            await redisDatabase.StringSetAsync(
+            _ = transaction.StringSetAsync(
                 transactionHash,
                 JsonSerializer.Serialize(newRecord),
                 expiry: CacheTime);

--- a/test/ProjectOrigin.Registry.Tests/TransactionStatusCache/InMemoryTransactionStatusServiceTests.cs
+++ b/test/ProjectOrigin.Registry.Tests/TransactionStatusCache/InMemoryTransactionStatusServiceTests.cs
@@ -9,15 +9,17 @@ namespace ProjectOrigin.Registry.Tests.TransactionStatusCache;
 
 public class InMemoryTransactionStatusServiceTests : AbstractTransactionStatusServiceTests
 {
-    private InMemoryTransactionStatusService _service;
+    private readonly Mock<ILogger<InMemoryTransactionStatusService>> _mockLogger;
+    private readonly InMemoryTransactionStatusService _service;
 
     public InMemoryTransactionStatusServiceTests()
     {
         var cache = new MemoryDistributedCache(MsOptions.Create(new MemoryDistributedCacheOptions()));
-        var logger = new Mock<ILogger<InMemoryTransactionStatusService>>();
+        _mockLogger = new Mock<ILogger<InMemoryTransactionStatusService>>();
 
-        _service = new InMemoryTransactionStatusService(logger.Object, cache, _repository);
+        _service = new InMemoryTransactionStatusService(_mockLogger.Object, cache, _repository);
     }
 
     protected override ITransactionStatusService Service => _service;
+    protected override IInvocationList LoggedMessages => _mockLogger.Invocations;
 }

--- a/test/ProjectOrigin.Registry.Tests/TransactionStatusCache/RedisTransactionStatusServiceTests.cs
+++ b/test/ProjectOrigin.Registry.Tests/TransactionStatusCache/RedisTransactionStatusServiceTests.cs
@@ -9,14 +9,17 @@ namespace ProjectOrigin.Registry.Tests.TransactionStatusCache;
 
 public class RedisTransactionStatusServiceTests : AbstractTransactionStatusServiceTests, IClassFixture<RedisFixture>
 {
-    private RedisTransactionStatusService _service;
+    private readonly Mock<ILogger<RedisTransactionStatusService>> _mockLogger;
+    private readonly RedisTransactionStatusService _service;
 
     public RedisTransactionStatusServiceTests(RedisFixture redisFixture)
     {
         var connection = ConnectionMultiplexer.Connect(redisFixture.HostConnectionString);
-        var logger = new Mock<ILogger<RedisTransactionStatusService>>();
-        _service = new RedisTransactionStatusService(logger.Object, connection, _repository);
+        _mockLogger = new Mock<ILogger<RedisTransactionStatusService>>();
+
+        _service = new RedisTransactionStatusService(_mockLogger.Object, connection, _repository);
     }
 
     protected override ITransactionStatusService Service => _service;
+    protected override IInvocationList LoggedMessages => _mockLogger.Invocations;
 }


### PR DESCRIPTION
Correct the transaction handling in the Redis status service to ensure proper usage of transactions and add tests to verify that setting transaction statuses multiple times does not generate warnings.